### PR TITLE
feat: add user pages endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { DocumentsModule } from './documents/documents.module';
 import { AiModule } from './ai/ai.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { AwsModule } from './aws/aws.module';
+import { RolesModule } from './roles/roles.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 
 @Module({
@@ -23,6 +24,7 @@ import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
     ]),
     AuthModule,
     UsersModule,
+    RolesModule,
     PdfModule,
     DocumentsModule,
     AiModule,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -70,8 +70,8 @@ export class AuthService {
   }
 
   private generateTokens(user: any) {
-    const roles = user.rol_usuario?.map((r: any) => r.rol.nombre) ?? [];
-    const payload = { sub: user.id, email: user.correo_institucional, roles };
+    const roleIds = user.rol_usuario?.map((r: any) => r.rol_id) ?? [];
+    const payload = { sub: user.id, email: user.correo_institucional, roleIds };
     const access_token = signJwt(payload, {
       secret: envs.jwtAccessSecret,
       expiresIn: envs.jwtAccessExpiration,

--- a/src/auth/decorators/roles.decorator.ts
+++ b/src/auth/decorators/roles.decorator.ts
@@ -1,4 +1,4 @@
 import { SetMetadata } from '@nestjs/common';
 
 export const ROLES_KEY = 'roles';
-export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);
+export const Roles = (...roles: number[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -13,7 +13,7 @@ export class RolesGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean {
     const requiredRoles =
-      this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      this.reflector.getAllAndOverride<number[]>(ROLES_KEY, [
         context.getHandler(),
         context.getClass(),
       ]) || [];
@@ -22,7 +22,7 @@ export class RolesGuard implements CanActivate {
     }
     const { user } = context.switchToHttp().getRequest();
     if (!user) throw new UnauthorizedException('No user in request');
-    const roles: string[] = user.roles || [];
-    return requiredRoles.some((role) => roles.includes(role));
+    const roleIds: number[] = user.roleIds || [];
+    return requiredRoles.some((role) => roleIds.includes(role));
   }
 }

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -3,7 +3,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 
-type JwtPayload = { sub: number; email: string; roles?: string[] };
+type JwtPayload = { sub: number; email: string; roleIds?: number[] };
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -19,7 +19,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     return {
       sub: payload.sub,
       email: payload.email,
-      roles: payload.roles ?? [],
+      roleIds: payload.roleIds ?? [],
     };
   }
 }

--- a/src/roles/roles.module.ts
+++ b/src/roles/roles.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { RolesService } from './roles.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [RolesService],
+  exports: [RolesService],
+})
+export class RolesModule {}
+

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+interface PageDto {
+  id: number;
+  nombre: string;
+  url: string;
+}
+
+@Injectable()
+export class RolesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getPagesForUser(userId: number): Promise<PageDto[]> {
+    const roles = await this.prisma.rol_usuario.findMany({
+      where: {
+        user_id: userId,
+        rol: { activo: true },
+      },
+      select: { rol_id: true },
+    });
+
+    const roleIds = roles.map((r) => r.rol_id);
+    if (roleIds.length === 0) return [];
+
+    const pages = await this.prisma.pagina.findMany({
+      where: {
+        activo: true,
+        pagina_rol: {
+          some: {
+            rol_id: { in: roleIds },
+            rol: { activo: true },
+          },
+        },
+      },
+      select: { id: true, nombre: true, url: true },
+      orderBy: { id: 'asc' },
+    });
+
+    return pages;
+  }
+}
+

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -13,10 +13,14 @@ import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesService } from '../roles/roles.service';
 
 @Controller('users')
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly rolesService: RolesService,
+  ) {}
 
   @Post()
   create(@Body() createUserDto: CreateUserDto) {
@@ -30,8 +34,16 @@ export class UsersController {
 
   @Get('me')
   @UseGuards(JwtAuthGuard)
-  me(@Req() req: any) {
-    return this.usersService.me(req.user.sub);
+  async me(@Req() req: any) {
+    const user = await this.usersService.findOne(req.user.sub);
+    if (!user) return null;
+    const pages = await this.rolesService.getPagesForUser(user.id);
+    return {
+      id: user.id,
+      nombre: user.primer_nombre,
+      correo: user.correo_institucional,
+      pages,
+    };
   }
 
   @Get(':id')

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -4,9 +4,10 @@ import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
+import { RolesModule } from '../roles/roles.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule], 
+  imports: [PrismaModule, AuthModule, RolesModule],
   controllers: [UsersController],
   providers: [UsersService],
 })


### PR DESCRIPTION
## Summary
- expose `/api/v1/users/me` with assigned pages
- centralize page lookup in new `RolesService`
- keep JWT minimal with user id, email and role IDs

## Testing
- `npm run lint` *(fails: Unsafe member access...)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b35a473c833285bb76a91de302c3