### PR TITLE
feat(roles): manage role pages and audit

### DIFF
--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -5,10 +5,12 @@ import {
   Get,
   Param,
   Patch,
+  Put,
   Post,
   Query,
   UseGuards,
   ParseIntPipe,
+  Req,
 } from '@nestjs/common';
 import { RolesService } from './roles.service';
 import { CreateRolDto } from './dto/create-rol.dto';
@@ -33,6 +35,20 @@ export class RolesController {
   @Patch(':id')
   update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateRolDto) {
     return this.rolesService.update(id, dto);
+  }
+
+  @Get(':id/paginas')
+  getPages(@Param('id', ParseIntPipe) id: number) {
+    return this.rolesService.getPages(id);
+  }
+
+  @Put(':id/paginas')
+  setPages(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: { paginaIds: number[] },
+    @Req() req: any,
+  ) {
+    return this.rolesService.setPages(id, body.paginaIds ?? [], req.user.sub);
   }
 
   @Delete(':id')

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -1,4 +1,9 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { Prisma } from '@prisma/client';
 import { CreateRolDto } from './dto/create-rol.dto';
@@ -63,6 +68,72 @@ export class RolesService {
     return this.prisma.rol.update({
       where: { id },
       data: { activo: true, updated_at: new Date() },
+    });
+  }
+
+  async getPages(id: number) {
+    const rol = await this.prisma.rol.findUnique({ where: { id } });
+    if (!rol) {
+      throw new NotFoundException('El rol no existe');
+    }
+    if (!rol.activo) {
+      throw new BadRequestException('El rol está inactivo');
+    }
+    const pages = await this.prisma.pagina_rol.findMany({
+      where: { rol_id: id, pagina: { activo: true } },
+      select: { pagina_id: true },
+      orderBy: { pagina_id: 'asc' },
+    });
+    return { paginaIds: pages.map((p) => p.pagina_id) };
+  }
+
+  async setPages(id: number, paginaIds: number[], userId: number) {
+    const rol = await this.prisma.rol.findUnique({ where: { id } });
+    if (!rol) {
+      throw new NotFoundException('El rol no existe');
+    }
+    if (!rol.activo) {
+      throw new BadRequestException('El rol está inactivo');
+    }
+
+    const uniqueIds = Array.from(new Set(paginaIds));
+    if (uniqueIds.length > 0) {
+      const pages = await this.prisma.pagina.findMany({
+        where: { id: { in: uniqueIds }, activo: true },
+        select: { id: true },
+      });
+      if (pages.length !== uniqueIds.length) {
+        throw new BadRequestException(
+          'Una o más páginas no existen o están inactivas',
+        );
+      }
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const before = await tx.pagina_rol.findMany({
+        where: { rol_id: id },
+        select: { pagina_id: true },
+      });
+      await tx.pagina_rol.deleteMany({ where: { rol_id: id } });
+      if (uniqueIds.length > 0) {
+        await tx.pagina_rol.createMany({
+          data: uniqueIds.map((pid) => ({ rol_id: id, pagina_id: pid })),
+          skipDuplicates: true,
+        });
+      }
+      await tx.auditoria.create({
+        data: {
+          user_id: userId,
+          entidad: 'rol',
+          entidad_id: id,
+          accion: 'SET_PAGINAS',
+          descripcion: JSON.stringify({
+            before: before.map((b) => b.pagina_id),
+            after: uniqueIds,
+          }),
+        },
+      });
+      return { paginaIds: uniqueIds };
     });
   }
 


### PR DESCRIPTION
## Summary
- add endpoints to retrieve and set role page assignments
- log auditing when role pages are replaced

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0b878fbf08332b2c5c6549882ff2b