### PR TITLE
feat: include role names in user profile and revise seed

### DIFF
--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -165,4 +165,13 @@ export class RolesService {
 
     return pages;
   }
+
+  // NUEVO MÉTODO
+  async getRoleNamesForUser(userId: number): Promise<string[]> {
+    const rows = await this.prisma.rol_usuario.findMany({
+      where: { user_id: userId },
+      select: { rol: { select: { nombre: true } } },
+    });
+    return rows.map((r) => r.rol.nombre);
+  }
 }

--- a/src/users/dto/me-response.dto.ts
+++ b/src/users/dto/me-response.dto.ts
@@ -9,4 +9,5 @@ export class MeResponseDto {
   nombre!: string;
   correo!: string;
   pages!: MePageDto[];
+  roles!: string[];
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -38,12 +38,16 @@ export class UsersController {
   async me(@Req() req: any): Promise<MeResponseDto | null> {
     const user = await this.usersService.findOne(req.user.sub);
     if (!user) return null;
-    const pages = (await this.rolesService.getPagesForUser(user.id)) as MePageDto[];
+    const [pages, roles] = await Promise.all([
+      this.rolesService.getPagesForUser(user.id),
+      this.rolesService.getRoleNamesForUser(user.id),
+    ]);
     return {
       id: user.id,
       nombre: user.primer_nombre,
       correo: user.correo_institucional,
-      pages,
+      pages: pages as MePageDto[],
+      roles,
     };
   }
 


### PR DESCRIPTION
## Summary
- add utility to retrieve user role names
- extend /users/me to return roles and pages
- reseed pages and role assignments to match frontend

## Testing
- `yarn db:generate`
- `yarn db:migrate` *(fails: Can't reach database server at `localhost:5432`)*
- `yarn db:seed` *(fails: Can't reach database server at `localhost:5432`)*
- `yarn start:dev` *(fails: Missing credentials. Please pass an `apiKey`, or set the `OPENAI_API_KEY` environment variable.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1495128808332898c566c13402ad5