### PR TITLE
Improve cuadro firmas details and fix supervision stats

### DIFF
--- a/src/aws/aws.service.ts
+++ b/src/aws/aws.service.ts
@@ -94,7 +94,7 @@ export class AWSService {
       Bucket: envs.bucketName,
       Key: fileKey,
       ResponseContentType: 'application/pdf',
-      ResponseContentDisposition: `inline;fileName=${fileName}.pdf`,
+      ResponseContentDisposition: `inline; filename="${fileName}.pdf"`,
     });
 
     try {

--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -97,14 +97,20 @@ export class DocumentsController {
   }
 
   @Get('cuadro-firmas/:id')
-  async findCuadroFirmas(@Param('id') id: string) {
+  async findCuadroFirmas(
+    @Param('id') id: string,
+    @Query('expiresIn') expiresIn?: string,
+  ) {
     const cuadroFirmasDB = await this.documentsService.findCuadroFirma(+id);
+    const exp = expiresIn ? +expiresIn : undefined;
     const urlCuadroFirmasPDF = await this.documentsService.getDocumentoURLBucket(
       cuadroFirmasDB.nombre_pdf,
+      exp,
     );
     const documentoDB = await this.documentsService.getDocumentoByCuadroFirmaID(+id);
     const urlDocumento = await this.documentsService.getDocumentoURLBucket(
       documentoDB.data.nombre_archivo,
+      exp,
     );
     return {
       urlCuadroFirmasPDF: urlCuadroFirmasPDF.data,

--- a/src/documents/interfaces/cuadro-firma.interface.ts
+++ b/src/documents/interfaces/cuadro-firma.interface.ts
@@ -1,53 +1,59 @@
-
-
-export interface CuadroFirmaDB  {
-  id: number,
-  titulo: string,
-  descripcion: string,
-  version: string,
-  nombre_pdf: string,
-  codigo: string,
-  empresa_id: number,
-  created_by: number,
+export interface CuadroFirmaDB {
+  id: number;
+  titulo: string;
+  descripcion: string;
+  version: string;
+  nombre_pdf: string;
+  codigo: string;
+  empresa_id: number;
+  created_by: number;
+  add_date?: Date;
+  progress?: number;
+  diasTranscurridosDocumento?: number;
   user: {
-    id: number,
-    primer_nombre: string,
-    segundo_name: string,
-    tercer_nombre: string,
-    primer_apellido: string,
-    segundo_apellido: string,
-    apellido_casada: string,
-    correo_institucional: string,
-    gerencia: { id: number, nombre: string },
-    posicion: { id: number, nombre: string }
-  },
+    id: number;
+    primer_nombre: string;
+    segundo_name: string;
+    tercer_nombre: string;
+    primer_apellido: string;
+    segundo_apellido: string;
+    apellido_casada: string;
+    correo_institucional: string;
+    gerencia: { id: number; nombre: string };
+    posicion: { id: number; nombre: string };
+  };
   estado_firma: {
-    nombre: string,
-    descripcion: string
-  },
+    nombre: string;
+    descripcion: string;
+  };
   cuadro_firma_estado_historial: Array<{
-    observaciones: string,
-    fecha_observacion: Date,
-    updated_at: Date,
-    user: any, // según tu modelo
-    estado_firma: any // según tu modelo
-  }>,
+    observaciones: string;
+    fecha_observacion: Date;
+    updated_at: Date;
+    user: any;
+    estado_firma: any;
+  }>;
   cuadro_firma_user: Array<{
+    estaFirmado: boolean | null;
+    fecha_firma: Date | null;
+    diasTranscurridos?: number;
     user: {
-      id: number,
-      primer_nombre: string,
-      segundo_name: string,
-      tercer_nombre: string,
-      primer_apellido: string,
-      segundo_apellido: string,
-      apellido_casada: string,
-      correo_institucional: string,
-      gerencia: { id: number, nombre: string },
-      posicion: { id: number, nombre: string }
-    },
+      id: number;
+      primer_nombre: string;
+      segundo_name: string;
+      tercer_nombre: string;
+      primer_apellido: string;
+      segundo_apellido: string;
+      apellido_casada: string;
+      correo_institucional: string;
+      codigo_empleado: string;
+      gerencia: { id: number; nombre: string };
+      posicion: { id: number; nombre: string };
+    };
     responsabilidad_firma: {
-      id: number,
-      nombre: string
-    }
-  }>
+      id: number;
+      nombre: string;
+      orden: number | null;
+    };
+  }>;
 }


### PR DESCRIPTION
## Summary
- Fix getSupervisionStats to handle null values and map state names
- Return ordered firmantes with signing info and calculate progress and days elapsed for documents
- Support inline PDF presigned URLs with optional expiration

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68c6ab0a25a48332bac175aa0ad2b257