### PR TITLE
feat: fill signer metadata via PDF text anchors

### DIFF
--- a/src/documents/utils/generar-filas-firma.utils.ts
+++ b/src/documents/utils/generar-filas-firma.utils.ts
@@ -1,47 +1,48 @@
-import { FirmanteUserDto } from "../dto/create-cuadro-firma.dto";
+import { FirmanteUserDto } from '../dto/create-cuadro-firma.dto';
 
 function htmlEscape(s: string): string {
   // Evita inyectar HTML en nombres/puestos/gerencias
   return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-function safeSlug(nombre?: string, fallback = "SIN_NOMBRE"): string {
-  const n = (nombre ?? "").trim();
-  return n ? n.replace(/\s+/g, "_") : fallback;
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 export function generarFilasFirmas(
   firmantes: FirmanteUserDto[] | undefined,
-  tipo: "APRUEBA" | "REVISA",
+  tipo: 'APRUEBA' | 'REVISA',
   labelPrimeraFila: string,
 ): string {
-  if (!Array.isArray(firmantes) || firmantes.length === 0) return "";
+  const filas =
+    Array.isArray(firmantes) && firmantes.length > 0 ? firmantes : [undefined];
 
-  return firmantes
+  return filas
     .map((f, index) => {
-      const rowLabel = index === 0 ? labelPrimeraFila : "";
-      const nombre = (f?.nombre ?? "").trim();
-      const puesto = f?.puesto ?? "";
-      const gerencia = f?.gerencia ?? "";
+      const rowLabel = index === 0 ? labelPrimeraFila : '';
+      const nombre = (f?.nombre ?? '').trim();
+      const puesto = f?.puesto ?? '';
+      const gerencia = f?.gerencia ?? '';
 
-      // Este slug se usa en el placeholder de FECHA para firmar luego:
-      // debe coincidir con la lógica del "sign" (nombre con _)
-      const slug = safeSlug(nombre, tipo);
+      const slug = nombre ? nombre.replace(/\s+/g, '_') : tipo;
+
+      const cellNombre = nombre ? htmlEscape(nombre) : `NOMBRE_${tipo}_${slug}`;
+      const cellPuesto = puesto ? htmlEscape(puesto) : `PUESTO_${tipo}_${slug}`;
+      const cellGerencia = gerencia
+        ? htmlEscape(gerencia)
+        : `GERENCIA_${tipo}_${slug}`;
+      const cellFecha = `FECHA_${tipo}_${slug}`;
 
       return `
 <tr class="tr-firmas">
   <td class="row-label">${htmlEscape(rowLabel)}</td>
-  <td>${htmlEscape(nombre)}</td>
-  <td>${htmlEscape(puesto)}</td>
-  <td>${htmlEscape(gerencia)}</td>
+  <td>${cellNombre}</td>
+  <td>${cellPuesto}</td>
+  <td>${cellGerencia}</td>
   <td class="td-firma"></td>
-  <td>FECHA_${tipo}_${slug}</td>
+  <td>${cellFecha}</td>
 </tr>`.trim();
     })
-    .join("");
+    .join('');
 }

--- a/src/pdf/domain/repositories/pdf.repository.ts
+++ b/src/pdf/domain/repositories/pdf.repository.ts
@@ -1,5 +1,5 @@
-import { Signature } from "src/documents/dto/sign-document.dto";
-import { SignaturePosition } from "../value-objects/signature-position.vo";
+import { Signature } from 'src/documents/dto/sign-document.dto';
+import { SignaturePosition } from '../value-objects/signature-position.vo';
 
 export const PDF_REPOSITORY = Symbol('PDF_REPOSITORY');
 
@@ -15,15 +15,18 @@ export interface PdfRepository {
     pdfBuffer: Buffer,
     signatureBuffer: Buffer,
     placeholder: string,
-    position: SignaturePosition
-  ): Promise<Buffer|null>;
+    position: SignaturePosition,
+  ): Promise<Buffer | null>;
   insertMultipleSignature(
     pdfBuffer: Buffer,
     signatures: Signature[],
-    position: SignaturePosition
-  ): Promise<Buffer|null>;
+    position: SignaturePosition,
+  ): Promise<Buffer | null>;
 
-  extractText(
+  extractText(pdfBuffer: Buffer): Promise<string>;
+
+  fillTextAnchors(
     pdfBuffer: Buffer,
-  ): Promise<string>;
+    replacements: Record<string, string>,
+  ): Promise<Buffer>;
 }


### PR DESCRIPTION
## Summary
- add text anchor filling in `DocumentsService.signDocument` to write signer name, position, and management before stamping the signature
- ensure template generation emits fallback anchors for Elabora and signature rows when data is missing
- extend the PDF repository with a `fillTextAnchors` helper implemented in the pdf-lib adapter

## Testing
- `npx eslint src/documents/documents.service.ts src/documents/utils/generar-filas-firma.utils.ts src/pdf/domain/repositories/pdf.repository.ts src/pdf/infrastructure/pdf-lib.repository.ts` *(fails: repository has pre-existing eslint violations across documents.service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c9824fdf608332a256e2ebb1633a48