### PR TITLE
feat: enhance signature filling with role metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,10 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1",
+      "^generated/(.*)$": "<rootDir>/../generated/$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/src/documents/documents.service.spec.ts
+++ b/src/documents/documents.service.spec.ts
@@ -1,0 +1,240 @@
+jest.mock('src/config/envs', () => ({
+  envs: {
+    port: 0,
+    apiPrefix: '',
+    corsOrigin: [],
+    nodeEnv: 'test',
+    databaseUrl: 'test',
+    jwtAccessSecret: 'secret',
+    jwtRefreshSecret: 'secret',
+    jwtAccessExpiration: 0,
+    jwtRefreshExpiration: 0,
+    bucketRegion: '',
+    bucketName: '',
+    bucketPrefix: '',
+    bucketSignaturesPrefix: '',
+    bucketAccessKeyID: '',
+    bucketSecretKey: '',
+    openAiAPIKey: '',
+    openAiModel: '',
+  },
+}));
+
+jest.mock('src/aws/aws.service', () => ({
+  AWSService: class {},
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { DocumentsService } from './documents.service';
+import { FirmaCuadroDto } from './dto/firma-cuadro.dto';
+import {
+  OFFSETS_DEFAULT,
+  SIGNATURE_DEFAULT,
+  type PdfRepository,
+  type TextAnchorFill,
+} from '../pdf/domain/repositories/pdf.repository';
+
+const createService = () => {
+  const pdfRepository: jest.Mocked<PdfRepository> = {
+    insertSignature: jest.fn(),
+    insertMultipleSignature: jest.fn(),
+    extractText: jest.fn(),
+    fillTextAnchors: jest.fn(),
+    fillRelativeToAnchor: jest.fn(),
+  } as unknown as jest.Mocked<PdfRepository>;
+
+  const prisma = {
+    cuadro_firma: {
+      findFirst: jest
+        .fn()
+        .mockResolvedValue({ nombre_pdf: 'test.pdf', pdf: null }),
+      findUnique: jest.fn().mockResolvedValue({
+        estado_firma: { nombre: 'En Progreso' },
+        estado_firma_id: 2,
+      }),
+      update: jest.fn().mockResolvedValue(undefined),
+    },
+    cuadro_firma_user: {
+      count: jest.fn().mockResolvedValue(1),
+    },
+    user: {
+      findUnique: jest.fn().mockResolvedValue({
+        primer_nombre: 'Juan',
+        primer_apellido: 'Perez',
+        posicion: { nombre: 'Analista' },
+        gerencia: { nombre: 'Tecnología' },
+      }),
+    },
+  } as any;
+
+  const cuadroFirmasRepository = {
+    validarOrdenFirma: jest.fn().mockResolvedValue(undefined),
+    updateCuadroFirmaUser: jest.fn().mockResolvedValue(undefined),
+    agregarHistorialCuadroFirma: jest.fn().mockResolvedValue({} as any),
+  } as any;
+
+  const documentosRepository = {} as any;
+  const pdfGeneratorRepository = {} as any;
+
+  const pdfBaseBuffer = Buffer.from('PDF_BASE');
+  const awsService = {
+    getFileBuffer: jest.fn().mockResolvedValue(pdfBaseBuffer),
+    uploadFile: jest.fn().mockResolvedValue(undefined),
+  } as any;
+
+  const service = new DocumentsService(
+    cuadroFirmasRepository,
+    documentosRepository,
+    pdfRepository,
+    pdfGeneratorRepository,
+    prisma,
+    awsService,
+  );
+
+  return {
+    service,
+    pdfRepository,
+    prisma,
+    awsService,
+    cuadroFirmasRepository,
+    pdfBaseBuffer,
+  };
+};
+
+const baseDto: FirmaCuadroDto = {
+  userId: '1',
+  nombreUsuario: 'Juan Perez',
+  cuadroFirmaId: '10',
+  responsabilidadId: '5',
+  nombreResponsabilidad: 'Elabora',
+  useStoredSignature: false,
+};
+
+describe('DocumentsService.signDocument', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('usa anchors de texto cuando existen todos los tokens', async () => {
+    const { service, pdfRepository, awsService } = createService();
+    const resolved = 'FECHA_ELABORA_ELABORA_TEST';
+
+    jest
+      .spyOn<any, any>(service as any, 'resolvePlaceholderInPdf')
+      .mockResolvedValue({
+        resolved,
+        primary: resolved,
+        candidates: [resolved],
+      });
+
+    pdfRepository.extractText.mockResolvedValue(
+      [
+        'NOMBRE_ELABORA_ELABORA_TEST',
+        'PUESTO_ELABORA_ELABORA_TEST',
+        'GERENCIA_ELABORA_ELABORA_TEST',
+        resolved,
+      ].join(' '),
+    );
+
+    const textBuffer = Buffer.from('with-text');
+    pdfRepository.fillTextAnchors.mockResolvedValue(textBuffer);
+
+    const signedBuffer = Buffer.from('signed');
+    pdfRepository.insertSignature.mockResolvedValue(signedBuffer);
+
+    const signatureBuffer = Buffer.from('signature-image');
+    const response = await service.signDocument(baseDto, signatureBuffer);
+
+    expect(pdfRepository.fillTextAnchors).toHaveBeenCalledTimes(1);
+    const [, items] = pdfRepository.fillTextAnchors.mock.calls[0];
+    expect((items as TextAnchorFill[])).toHaveLength(4);
+    expect((items as TextAnchorFill[]).map((item) => item.token)).toEqual(
+      expect.arrayContaining([
+        'NOMBRE_ELABORA_ELABORA_TEST',
+        'PUESTO_ELABORA_ELABORA_TEST',
+        'GERENCIA_ELABORA_ELABORA_TEST',
+        resolved,
+      ]),
+    );
+    expect(pdfRepository.fillRelativeToAnchor).not.toHaveBeenCalled();
+    expect(pdfRepository.insertSignature).toHaveBeenCalledWith(
+      textBuffer,
+      signatureBuffer,
+      resolved,
+      undefined,
+    );
+    expect(awsService.uploadFile).toHaveBeenCalledWith(
+      signedBuffer,
+      'test.pdf',
+    );
+    expect(response).toEqual({
+      status: expect.any(Number),
+      data: expect.any(String),
+    });
+  });
+
+  it('usa offsets relativos cuando faltan tokens', async () => {
+    const { service, pdfRepository, awsService, pdfBaseBuffer } =
+      createService();
+    const resolved = 'FECHA_ELABORA_ELABORA_TEST';
+
+    jest
+      .spyOn<any, any>(service as any, 'resolvePlaceholderInPdf')
+      .mockResolvedValue({
+        resolved,
+        primary: resolved,
+        candidates: [resolved],
+      });
+
+    pdfRepository.extractText.mockResolvedValue(resolved);
+
+    const relativeBuffer = Buffer.from('relative');
+    pdfRepository.fillRelativeToAnchor.mockResolvedValue(relativeBuffer);
+
+    const signatureBuffer = Buffer.from('signature-image');
+    const response = await service.signDocument(baseDto, signatureBuffer);
+
+    expect(pdfRepository.fillTextAnchors).not.toHaveBeenCalled();
+    expect(pdfRepository.fillRelativeToAnchor).toHaveBeenCalledWith(
+      pdfBaseBuffer,
+      resolved,
+      expect.objectContaining({
+        NOMBRE: expect.stringContaining('Juan'),
+        PUESTO: 'Analista',
+        GERENCIA: 'Tecnología',
+      }),
+      OFFSETS_DEFAULT,
+      expect.objectContaining({
+        dx: SIGNATURE_DEFAULT.dx,
+        dy: SIGNATURE_DEFAULT.dy,
+        width: SIGNATURE_DEFAULT.width,
+        height: SIGNATURE_DEFAULT.height,
+      }),
+    );
+    expect(pdfRepository.insertSignature).not.toHaveBeenCalled();
+    expect(awsService.uploadFile).toHaveBeenCalledWith(
+      relativeBuffer,
+      'test.pdf',
+    );
+    expect(response).toEqual({
+      status: expect.any(Number),
+      data: expect.any(String),
+    });
+  });
+
+  it('lanza error si no encuentra el placeholder FECHA', async () => {
+    const { service } = createService();
+
+    jest
+      .spyOn<any, any>(service as any, 'resolvePlaceholderInPdf')
+      .mockResolvedValue({
+        resolved: null,
+        primary: 'FECHA_ELABORA_FAKE',
+        candidates: [],
+      });
+
+    await expect(
+      service.signDocument(baseDto, Buffer.from('signature-image')),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/src/pdf/domain/repositories/pdf.repository.ts
+++ b/src/pdf/domain/repositories/pdf.repository.ts
@@ -3,6 +3,24 @@ import { SignaturePosition } from '../value-objects/signature-position.vo';
 
 export const PDF_REPOSITORY = Symbol('PDF_REPOSITORY');
 
+export interface TextAnchorFill {
+  token: string;
+  text: string;
+  fontSize?: number;
+  maxWidth?: number;
+  rectPadding?: number;
+}
+
+export type RelativeField = {
+  key: 'NOMBRE' | 'PUESTO' | 'GERENCIA' | 'FECHA' | 'FIRMA_BOX';
+  dx: number;
+  dy: number;
+  maxWidth?: number;
+  rectWidth?: number;
+  rectHeight?: number;
+  fontSize?: number;
+};
+
 export interface PdfRepository {
   /**
    * Inserta una imagen de firma en un PDF en la posición indicada.
@@ -27,6 +45,75 @@ export interface PdfRepository {
 
   fillTextAnchors(
     pdfBuffer: Buffer,
-    replacements: Record<string, string>,
+    items: TextAnchorFill[],
+  ): Promise<Buffer>;
+
+  fillRelativeToAnchor(
+    pdfBuffer: Buffer,
+    anchorToken: string,
+    values: Record<'NOMBRE' | 'PUESTO' | 'GERENCIA' | 'FECHA', string>,
+    fields: RelativeField[],
+    signature?: {
+      buffer: Buffer;
+      dx: number;
+      dy: number;
+      width: number;
+      height: number;
+    },
   ): Promise<Buffer>;
 }
+
+export const CELL = { height: 22, textSize: 8 } as const;
+
+export const OFFSETS_DEFAULT: RelativeField[] = [
+  {
+    key: 'NOMBRE',
+    dx: -470,
+    dy: 0,
+    maxWidth: 110,
+    rectWidth: 110,
+    rectHeight: CELL.height,
+    fontSize: CELL.textSize,
+  },
+  {
+    key: 'PUESTO',
+    dx: -360,
+    dy: 0,
+    maxWidth: 110,
+    rectWidth: 110,
+    rectHeight: CELL.height,
+    fontSize: CELL.textSize,
+  },
+  {
+    key: 'GERENCIA',
+    dx: -250,
+    dy: 0,
+    maxWidth: 110,
+    rectWidth: 110,
+    rectHeight: CELL.height,
+    fontSize: CELL.textSize,
+  },
+  {
+    key: 'FIRMA_BOX',
+    dx: -120,
+    dy: -25,
+    rectWidth: 150,
+    rectHeight: 50,
+  },
+  {
+    key: 'FECHA',
+    dx: 0,
+    dy: 0,
+    maxWidth: 90,
+    rectWidth: 80,
+    rectHeight: 22,
+    fontSize: 7,
+  },
+];
+
+export const SIGNATURE_DEFAULT = {
+  dx: -120,
+  dy: -25,
+  width: 100,
+  height: 40,
+} as const;


### PR DESCRIPTION
## Summary
- extend the PDF repository with token-based and relative fill operations plus reusable offset defaults
- update signDocument to log placeholder usage, fill role metadata, and fall back to relative positioning when anchors are missing
- add jest module aliases and unit tests covering anchor and fallback flows for Genesis-Sign signing

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c99a71ff8c8332bbd7b9a76d48e06f