### PR TITLE
feat(pdf): dynamic signature table filling

### DIFF
--- a/src/pdf/domain/repositories/pdf.repository.ts
+++ b/src/pdf/domain/repositories/pdf.repository.ts
@@ -1,6 +1,26 @@
 import { Signature } from 'src/documents/dto/sign-document.dto';
 import { SignaturePosition } from '../value-objects/signature-position.vo';
 
+export type SignatureTableColumn = { x: number; w: number };
+
+export type SignatureTableColumns = {
+  nombre: SignatureTableColumn;
+  puesto: SignatureTableColumn;
+  gerencia: SignatureTableColumn;
+  firma: SignatureTableColumn;
+  fecha: SignatureTableColumn;
+};
+
+export type FillRowByColumnsOptions = {
+  signatureBuffer?: Buffer;
+  writeDate?: boolean;
+};
+
+export type FillRowByColumnsResult = {
+  buffer: Buffer;
+  mode: 'columns' | 'fallback';
+};
+
 export const PDF_REPOSITORY = Symbol('PDF_REPOSITORY');
 
 export interface TextAnchorFill {
@@ -34,6 +54,7 @@ export interface PdfRepository {
     signatureBuffer: Buffer,
     placeholder: string,
     position: SignaturePosition,
+    options?: { writeDate?: boolean; drawSignature?: boolean },
   ): Promise<Buffer | null>;
   insertMultipleSignature(
     pdfBuffer: Buffer,
@@ -61,6 +82,18 @@ export interface PdfRepository {
       height: number;
     },
   ): Promise<Buffer>;
+
+  locateSignatureTableColumns(
+    pdfBuffer: Buffer,
+    page: number,
+  ): Promise<SignatureTableColumns | null>;
+
+  fillRowByColumns(
+    pdfBuffer: Buffer,
+    anchorToken: string,
+    values: Record<'NOMBRE' | 'PUESTO' | 'GERENCIA' | 'FECHA', string>,
+    options?: FillRowByColumnsOptions,
+  ): Promise<FillRowByColumnsResult>;
 }
 
 export const CELL = { height: 22, textSize: 8 } as const;


### PR DESCRIPTION
## Summary
- detect signature table columns in the PDF repository to drive dynamic cell filling
- add fillRowByColumns and update insertSignature to honour column widths and optional date handling
- switch the DocumentsService fallback to the new column-based flow and refresh its unit tests

## Testing
- npm test -- documents.service

------
https://chatgpt.com/codex/tasks/task_e_68c9a30ae6e08332842ec8c2cf35e2af