### PR TITLE
Adjust signature column alignment and HTML row generation

### DIFF
--- a/src/documents/utils/generar-filas-firma.utils.ts
+++ b/src/documents/utils/generar-filas-firma.utils.ts
@@ -1,48 +1,37 @@
-import { FirmanteUserDto } from '../dto/create-cuadro-firma.dto';
-
-function htmlEscape(s: string): string {
-  // Evita inyectar HTML en nombres/puestos/gerencias
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+export function slugNombre(v: string) {
+  return (v || '').trim().replace(/\s+/g, '_'); // igual a la generación actual
 }
 
+type Item = {
+  userId: number;
+  nombre: string;
+  puesto?: string;
+  gerencia?: string;
+};
+
 export function generarFilasFirmas(
-  firmantes: FirmanteUserDto[] | undefined,
-  tipo: 'APRUEBA' | 'REVISA',
-  labelPrimeraFila: string,
+  items: Item[] | Item | undefined,
+  rol: 'REVISA' | 'APRUEBA',
+  etiquetaIzquierda: string // 'Revisado por:' | 'Aprobado por:'
 ): string {
-  const filas =
-    Array.isArray(firmantes) && firmantes.length > 0 ? firmantes : [undefined];
+  const arr = Array.isArray(items) ? items : items ? [items] : [];
 
-  return filas
-    .map((f, index) => {
-      const rowLabel = index === 0 ? labelPrimeraFila : '';
-      const nombre = (f?.nombre ?? '').trim();
-      const puesto = f?.puesto ?? '';
-      const gerencia = f?.gerencia ?? '';
+  return arr.map((it) => {
+    const nombre = it?.nombre || '';
+    const puesto = it?.puesto || '';
+    const gerencia = it?.gerencia || '';
 
-      const slug = nombre ? nombre.replace(/\s+/g, '_') : tipo;
+    // ✅ Solo la FECHA queda como placeholder (ancla para firmar)
+    const fechaToken = `FECHA_${rol}_${slugNombre(nombre || rol)}`;
 
-      const cellNombre = nombre ? htmlEscape(nombre) : `NOMBRE_${tipo}_${slug}`;
-      const cellPuesto = puesto ? htmlEscape(puesto) : `PUESTO_${tipo}_${slug}`;
-      const cellGerencia = gerencia
-        ? htmlEscape(gerencia)
-        : `GERENCIA_${tipo}_${slug}`;
-      const cellFecha = `FECHA_${tipo}_${slug}`;
-
-      return `
-<tr class="tr-firmas">
-  <td class="row-label">${htmlEscape(rowLabel)}</td>
-  <td>${cellNombre}</td>
-  <td>${cellPuesto}</td>
-  <td>${cellGerencia}</td>
-  <td class="td-firma"></td>
-  <td>${cellFecha}</td>
-</tr>`.trim();
-    })
-    .join('');
+    return `
+<tr>
+  <td style="width:92px;padding:6px 4px;"><b>${etiquetaIzquierda}</b></td>
+  <td style="padding:6px 4px;">${nombre}</td>
+  <td style="padding:6px 4px;">${puesto}</td>
+  <td style="padding:6px 4px;">${gerencia}</td>
+  <td style="padding:6px 4px;"></td>
+  <td style="padding:6px 4px;">${fechaToken}</td>
+</tr>`;
+  }).join('');
 }

--- a/src/pdf/infrastructure/pdf-lib.repository.ts
+++ b/src/pdf/infrastructure/pdf-lib.repository.ts
@@ -350,13 +350,25 @@ export class PdfLibRepository implements PdfRepository {
 
     const resolved = columns as SignatureTableColumns;
 
+    const leftAligned: SignatureTableColumns = {
+      nombre: { x: resolved.nombre.x - resolved.nombre.w / 2, w: resolved.nombre.w },
+      puesto: { x: resolved.puesto.x - resolved.puesto.w / 2, w: resolved.puesto.w },
+      gerencia: {
+        x: resolved.gerencia.x - resolved.gerencia.w / 2,
+        w: resolved.gerencia.w,
+      },
+      firma: { x: resolved.firma.x - resolved.firma.w / 2, w: resolved.firma.w },
+      fecha: { x: resolved.fecha.x - resolved.fecha.w / 2, w: resolved.fecha.w },
+    };
+
     this.logger.log(
-      `[locateSignatureTableColumns] página ${page + 1} -> ${Object.entries(resolved)
-        .map(([key, value]) => `${key}=(x:${value.x.toFixed(2)},w:${value.w.toFixed(2)})`)
-        .join(', ')}`,
+      `[locateSignatureTableColumns] (left) página ${page + 1} -> ` +
+        Object.entries(leftAligned)
+          .map(([k, v]) => `${k}=(x:${v.x.toFixed(2)},w:${v.w.toFixed(2)})`)
+          .join(', '),
     );
 
-    return resolved;
+    return leftAligned;
   }
 
   async fillTextAnchors(
@@ -667,7 +679,7 @@ export class PdfLibRepository implements PdfRepository {
 
     const baselineY = anchor.y;
     const padding = this.defaultRectPadding;
-    const rowHeight = CELL.height + 8; // altura un poco mayor para limpiar bien
+    const rowHeight = CELL.height + 10; // altura un poco mayor para limpiar bien
 
     const columnOrder: Array<keyof SignatureTableColumns> = [
       'nombre',
@@ -696,7 +708,7 @@ export class PdfLibRepository implements PdfRepository {
       x: x0,
       y: baselineY - rowHeight,
       width: totalWidth,
-      height: rowHeight + 6, // un poco extra
+      height: rowHeight + 8, // un poco extra
       color: rgb(1, 1, 1),
       borderColor: rgb(1, 1, 1),
       borderWidth: 0,


### PR DESCRIPTION
## Summary
- align located signature table columns to their left edges and log adjusted coordinates
- expand the signature row cleanup rectangle for more reliable placeholder removal
- render signature table HTML rows with populated name, position, and management data while keeping the date placeholder

## Testing
- npm run lint *(fails: existing prettier/@typescript-eslint issues in prisma/seed and jest-e2e config)*

------
https://chatgpt.com/codex/tasks/task_e_68c9df68dd888332b6c7f089661639b7