### PR TITLE
Align signatures without altering template

### DIFF
--- a/src/documents/documents.service.ts
+++ b/src/documents/documents.service.ts
@@ -309,23 +309,23 @@ export class DocumentsService {
 
     this.logger.log('[signDocument] modo de llenado: columnas detectadas por encabezados');
 
-    // Limpieza previa de la fila para borrar placeholders y basura visual
+    // 1) Limpieza de la fila: borra placeholders y residuos previos
     const cleaned = await this.pdfRepository.fillRowByColumns(
       pdfBuffer,
       resolved,
       { NOMBRE: '', PUESTO: '', GERENCIA: '', FECHA: '' },
-      { writeDate: false }, // sin firma, sin fecha
+      { writeDate: false }, // sin fecha, sin firma; solo limpieza
     );
 
-    // Ahora escribir valores + firma con centrado y fecha centrada
+    // 2) Escritura definitiva: valores + firma + fecha (centradas)
     const finalRow = await this.pdfRepository.fillRowByColumns(
       cleaned.buffer,
       resolved,
       {
-        NOMBRE: displayName,
-        PUESTO: puesto,
-        GERENCIA: gerencia,
-        FECHA: fechaFirma,
+        NOMBRE: displayName, // “Carlos Ojani Ng Valladares” ya desde DB
+        PUESTO: puesto, // “CEO”
+        GERENCIA: gerencia, // “Dirección”
+        FECHA: fechaFirma, // ej. “16 de septiembre de 2025”
       },
       { signatureBuffer: signatureFileBuffer, writeDate: true },
     );


### PR DESCRIPTION
## Summary
- update the PDF repository helper to clean cells individually and center text/date output
- center and scale signature images while preserving the blue column styling
- adjust the document signing flow to clear placeholders before writing final values and signature

## Testing
- npx eslint src/pdf/infrastructure/pdf-lib.repository.ts src/documents/documents.service.ts *(fails: pre-existing lint violations throughout the files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ed68d6c88332a1024232cb600288