### PR TITLE
Hydrate responsables before generating cuadro firmas

### DIFF
--- a/src/common/utils/strings.ts
+++ b/src/common/utils/strings.ts
@@ -1,0 +1,11 @@
+export const safeStr = (v: any, fallback = ''): string =>
+  (v ?? fallback).toString();
+
+export const joinWithSpace = (
+  ...parts: Array<string | null | undefined>
+): string =>
+  parts
+    .filter(Boolean)
+    .map((p) => String(p).trim())
+    .filter(Boolean)
+    .join(' ');


### PR DESCRIPTION
## Summary
- add reusable string helpers for safe casting and spacing
- hydrate responsables by userId in DocumentsService, completing profile data and caching responsabilidad lookups
- ensure guardarCuadroFirmas and updateCuadroFirmas operate on hydrated responsables with clear 400 errors when data is missing

## Testing
- yarn lint *(fails due to pre-existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68ca731871e883329c5c2d434b2ac31a