### PR TITLE
feat: improve document listings and stats

### DIFF
--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -27,6 +27,7 @@ import { FirmaCuadroDto } from './dto/firma-cuadro.dto';
 import { JsonParsePipe } from 'src/common/json-pipe/json-pipe.pipe';
 import { UpdateEstadoAsignacionDto } from './dto/update-estado-asignacion.dto';
 import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { ListQueryDto } from './dto/list-query.dto';
 import { AWSService } from 'src/aws/aws.service';
 import { envs } from 'src/config/envs';
 
@@ -214,20 +215,27 @@ export class DocumentsController {
     return this.documentsService.getUsuariosFirmantesCuadroFirmas(+id);
   }
   
-  @Get('cuadro-firmas/by-user/:userId')
-  getAsignacionesByUserId(
-    @Param('userId') userId: string,
-    @Query() paginationDto: PaginationDto,
-  ) {
-    return this.documentsService.getAsignacionesByUserId(+userId, paginationDto);
-  }
-  
-
   @Get('cuadro-firmas/documentos/supervision')
-  getSueprvisionDocumentos(
-    @Query() paginationDto: PaginationDto,
+  async listSupervision(@Query() q: ListQueryDto) {
+    return this.documentsService.listSupervision(q);
+  }
+
+  @Get('cuadro-firmas/by-user/:userId')
+  async listByUser(@Param('userId') userId: string, @Query() q: ListQueryDto) {
+    return this.documentsService.listByUser(Number(userId), q);
+  }
+
+  @Get('cuadro-firmas/documentos/supervision/stats')
+  async stats(@Query() q: Pick<ListQueryDto, 'search'>) {
+    return this.documentsService.statsSupervision(q.search);
+  }
+
+  @Get('cuadro-firmas/by-user/:userId/stats')
+  async statsByUser(
+    @Param('userId') userId: string,
+    @Query() q: Pick<ListQueryDto, 'search'>,
   ) {
-    return this.documentsService.getSupervisionDocumentos(paginationDto);
+    return this.documentsService.statsByUser(Number(userId), q.search);
   }
   
   

--- a/src/documents/dto/list-query.dto.ts
+++ b/src/documents/dto/list-query.dto.ts
@@ -1,0 +1,23 @@
+import { IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class ListQueryDto {
+  @IsInt()
+  @Min(1)
+  page = 1;
+
+  @IsInt()
+  @Min(1)
+  limit = 10;
+
+  @IsIn(['asc', 'desc'])
+  @IsOptional()
+  sort: 'asc' | 'desc' = 'desc';
+
+  @IsString()
+  @IsOptional()
+  search?: string;
+
+  @IsString()
+  @IsOptional()
+  estado?: string;
+}


### PR DESCRIPTION
## Summary
- add reusable `ListQueryDto` for pagination, sorting and filtering
- update document supervision and user listings to use Prisma ordering, meta data and new stats endpoints
- extend tests to cover updated list responses and new stats routes

## Testing
- `yarn test --runTestsByPath test/documents.e2e-spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cac4a7fe6c8332816c99ea8f8256b6