### PR TITLE
feat: add catalogs and role assignment management

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,8 @@ import { AwsModule } from './aws/aws.module';
 import { RolesModule } from './roles/roles.module';
 import { PaginasModule } from './paginas/paginas.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { PosicionesModule } from './posiciones/posiciones.module';
+import { GerenciasModule } from './gerencias/gerencias.module';
 
 @Module({
   imports: [
@@ -32,6 +34,8 @@ import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
     AiModule,
     PrismaModule,
     AwsModule,
+    PosicionesModule,
+    GerenciasModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/gerencias/gerencias.controller.ts
+++ b/src/gerencias/gerencias.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GerenciasService } from './gerencias.service';
+
+@UseGuards(JwtAuthGuard)
+@Controller({ path: 'gerencias', version: '1' })
+export class GerenciasController {
+  constructor(private readonly gerenciasService: GerenciasService) {}
+
+  @Get()
+  findAll(@Query('all') all = '0') {
+    return this.gerenciasService.findAll(all === '1');
+  }
+}

--- a/src/gerencias/gerencias.module.ts
+++ b/src/gerencias/gerencias.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { GerenciasService } from './gerencias.service';
+import { GerenciasController } from './gerencias.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [GerenciasController],
+  providers: [GerenciasService],
+})
+export class GerenciasModule {}

--- a/src/gerencias/gerencias.service.ts
+++ b/src/gerencias/gerencias.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class GerenciasService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findAll(includeAll = false) {
+    return this.prisma.gerencia.findMany({
+      where: includeAll ? undefined : { activo: true },
+      orderBy: { id: 'asc' },
+      select: {
+        id: true,
+        nombre: true,
+        activo: true,
+      },
+    });
+  }
+}

--- a/src/posiciones/posiciones.controller.ts
+++ b/src/posiciones/posiciones.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PosicionesService } from './posiciones.service';
+
+@UseGuards(JwtAuthGuard)
+@Controller({ path: 'posiciones', version: '1' })
+export class PosicionesController {
+  constructor(private readonly posicionesService: PosicionesService) {}
+
+  @Get()
+  findAll(@Query('all') all = '0') {
+    return this.posicionesService.findAll(all === '1');
+  }
+}

--- a/src/posiciones/posiciones.module.ts
+++ b/src/posiciones/posiciones.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PosicionesService } from './posiciones.service';
+import { PosicionesController } from './posiciones.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PosicionesController],
+  providers: [PosicionesService],
+})
+export class PosicionesModule {}

--- a/src/posiciones/posiciones.service.ts
+++ b/src/posiciones/posiciones.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class PosicionesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findAll(includeAll = false) {
+    return this.prisma.posicion.findMany({
+      where: includeAll ? undefined : { activo: true },
+      orderBy: { id: 'asc' },
+      select: {
+        id: true,
+        nombre: true,
+        activo: true,
+      },
+    });
+  }
+}

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -18,6 +18,11 @@ export class RolesService {
     return this.prisma.rol.findMany({
       where: all ? undefined : { activo: true },
       orderBy: { id: 'asc' },
+      select: {
+        id: true,
+        nombre: true,
+        activo: true,
+      },
     });
   }
 
@@ -138,28 +143,30 @@ export class RolesService {
       select: { rol_id: true },
     });
 
-    const roleIds = roles.map(r => r.rol_id);
+    const roleIds = roles.map((r) => r.rol_id);
     if (roleIds.length === 0) return [];
 
     const pages = await this.prisma.pagina.findMany({
       where: {
         activo: true,
-        pagina_rol: { some: { rol_id: { in: roleIds }, rol: { activo: true } } },
+        pagina_rol: {
+          some: { rol_id: { in: roleIds }, rol: { activo: true } },
+        },
       },
       select: {
         id: true,
         nombre: true,
         url: true,
         icon: true,
-        order: true,        // <- si usaste @map("display_order")
+        order: true, // <- si usaste @map("display_order")
       },
       orderBy: [
-        { order: 'asc' },   // primero por orden custom
-        { id: 'asc' },      // luego por id
+        { order: 'asc' }, // primero por orden custom
+        { id: 'asc' }, // luego por id
       ],
     });
 
-    return pages.map(p => ({
+    return pages.map((p) => ({
       id: p.id,
       code: p.nombre,
       name: p.nombre,

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,18 +1,49 @@
-import { IsEmail, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsEmail, IsInt, IsOptional, IsString } from 'class-validator';
 
 export class CreateUserDto {
   @IsString({ message: 'primer_nombre must be a string' })
   primer_nombre: string;
 
+  @IsOptional()
+  @IsString({ message: 'segundo_name must be a string' })
+  segundo_name?: string;
+
+  @IsOptional()
+  @IsString({ message: 'tercer_nombre must be a string' })
+  tercer_nombre?: string;
+
   @IsString({ message: 'primer_apellido must be a string' })
   primer_apellido: string;
 
+  @IsOptional()
+  @IsString({ message: 'segundo_apellido must be a string' })
+  segundo_apellido?: string;
+
+  @IsOptional()
+  @IsString({ message: 'apellido_casada must be a string' })
+  apellido_casada?: string;
+
   @IsEmail({}, { message: 'correo_institucional must be a valid email' })
   correo_institucional: string;
+
+  @IsOptional()
+  @IsString({ message: 'telefono must be a string' })
+  telefono?: string;
 
   @IsString({ message: 'codigo_empleado must be a string' })
   codigo_empleado: string;
 
   @IsString({ message: 'password must be a string' })
   password: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'posicion_id must be an integer' })
+  posicion_id?: number | null;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'gerencia_id must be an integer' })
+  gerencia_id?: number | null;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,17 +1,19 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
-  UseGuards,
-  Req,
-  UseInterceptors,
-  UploadedFiles,
-  UploadedFile,
+  Get,
+  Param,
   ParseIntPipe,
+  Patch,
+  Post,
+  Put,
+  Query,
+  Req,
+  UploadedFile,
+  UploadedFiles,
+  UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor, FilesInterceptor } from '@nestjs/platform-express';
 import { UsersService } from './users.service';
@@ -31,14 +33,16 @@ export class UsersController {
   @UseInterceptors(FileInterceptor('foto'))
   create(
     @Body() createUserDto: CreateUserDto,
+    @Req() req: any,
     @UploadedFile() file?: Express.Multer.File,
   ) {
-    return this.usersService.create(createUserDto, file);
+    const roleIds = this.extractRoleIds(req?.body);
+    return this.usersService.create(createUserDto, file, roleIds);
   }
 
   @Get()
-  findAll() {
-    return this.usersService.findAll();
+  findAll(@Query('all') all = '0') {
+    return this.usersService.findAll(all === '1');
   }
 
   @Get('me')
@@ -67,9 +71,27 @@ export class UsersController {
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateUserDto: UpdateUserDto,
+    @Req() req: any,
     @UploadedFile() file?: Express.Multer.File,
   ) {
-    return this.usersService.update(id, updateUserDto, file);
+    const roleIds = this.extractRoleIds(req?.body);
+    return this.usersService.update(id, updateUserDto, file, roleIds);
+  }
+
+  @Get(':id/roles')
+  getRoles(@Param('id', ParseIntPipe) id: number) {
+    return this.usersService.getUserRoles(id);
+  }
+
+  @Put(':id/roles')
+  setRoles(
+    @Param('id', ParseIntPipe) id: number,
+    @Body('rolIds') rolIds?: unknown,
+  ) {
+    const normalized = this.normalizeRoleIds(
+      rolIds === undefined ? [] : Array.isArray(rolIds) ? rolIds : [rolIds],
+    );
+    return this.usersService.replaceUserRoles(id, normalized);
   }
 
   @Patch(':id/password')
@@ -87,5 +109,91 @@ export class UsersController {
   @Delete(':id')
   remove(@Param('id', ParseIntPipe) id: number) {
     return this.usersService.softDelete(id);
+  }
+
+  private extractRoleIds(payload: any): number[] | undefined {
+    if (!payload || typeof payload !== 'object') {
+      return undefined;
+    }
+
+    const keys = Object.keys(payload);
+    const candidates: unknown[] = [];
+    let hasRoles = false;
+
+    if (Object.prototype.hasOwnProperty.call(payload, 'roles')) {
+      candidates.push(payload.roles);
+      hasRoles = true;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(payload, 'roles[]')) {
+      candidates.push(payload['roles[]']);
+      hasRoles = true;
+    }
+
+    for (const key of keys) {
+      if (/^roles\[[^\]]*\]$/.test(key)) {
+        candidates.push(payload[key]);
+        hasRoles = true;
+      }
+    }
+
+    if (!hasRoles) {
+      return undefined;
+    }
+
+    return this.normalizeRoleIds(candidates);
+  }
+
+  private normalizeRoleIds(inputs: unknown[]): number[] {
+    const queue: unknown[] = [...inputs];
+    const normalized = new Set<number>();
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (current === undefined || current === null) {
+        continue;
+      }
+
+      if (Array.isArray(current)) {
+        queue.unshift(...current);
+        continue;
+      }
+
+      if (typeof current === 'object') {
+        queue.unshift(...Object.values(current));
+        continue;
+      }
+
+      if (typeof current === 'string') {
+        const trimmed = current.trim();
+        if (!trimmed) {
+          continue;
+        }
+
+        if (/^\[[\s\S]*\]$/.test(trimmed)) {
+          try {
+            const parsed = JSON.parse(trimmed);
+            queue.unshift(parsed);
+            continue;
+          } catch (error) {
+            // Ignore malformed JSON and try to parse as number below
+          }
+        }
+
+        const num = Number(trimmed);
+        if (Number.isInteger(num) && num > 0) {
+          normalized.add(num);
+        }
+        continue;
+      }
+
+      if (typeof current === 'number') {
+        if (Number.isInteger(current) && current > 0) {
+          normalized.add(current);
+        }
+      }
+    }
+
+    return Array.from(normalized.values());
   }
 }


### PR DESCRIPTION
## Summary
- add protected controllers/modules to list posiciones and gerencias with optional inclusion of inactive records
- update user DTO, controller, and service to accept role, gerencia, and posicion assignments and expose role management endpoints
- map user responses to include catalog names, role metadata, and photo URL resolution while reworking RolesService catalog output

## Testing
- yarn lint *(fails: existing prettier/unsafe access violations in project lint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4514737483328a5ad5d85012ae74