### PR TITLE
Add avatar URL to user me endpoint

### DIFF
--- a/src/shared/dto/me.dto.ts
+++ b/src/shared/dto/me.dto.ts
@@ -8,4 +8,5 @@ export interface MeResponseDto {
   roles: string[];
   signatureUrl: string | null;
   hasSignature: boolean;
+  avatarUrl: string | null;
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -331,6 +331,7 @@ export class UsersService {
         id: true,
         primer_nombre: true,
         correo_institucional: true,
+        url_foto: true,
       },
     });
     if (!user) {
@@ -354,6 +355,8 @@ export class UsersService {
       url = presigned.data;
     }
 
+    const avatarUrl = await this.resolvePhotoUrl(user.url_foto ?? null);
+
     return {
       id: user.id,
       nombre: user.primer_nombre,
@@ -362,6 +365,7 @@ export class UsersService {
       roles,
       signatureUrl: url,
       hasSignature: exists,
+      avatarUrl,
     };
   }
 


### PR DESCRIPTION
## Summary
- include the stored profile photo when building the `/v1/users/me` response
- resolve profile photo keys to HTTPS or presigned URLs and expose them as `avatarUrl`

## Testing
- yarn test *(fails: error TS5023: Unknown compiler option 'include')*


------
https://chatgpt.com/codex/tasks/task_e_68cc5b794c9083328d7d64eeb1358def