### PR TITLE
feat: add optional pagination to listings

### DIFF
--- a/src/paginas/paginas.controller.ts
+++ b/src/paginas/paginas.controller.ts
@@ -14,6 +14,7 @@ import { PaginasService } from './paginas.service';
 import { CreatePaginaDto } from './dto/create-pagina.dto';
 import { UpdatePaginaDto } from './dto/update-pagina.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PaginationDto } from 'src/shared/dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller({ path: 'paginas', version: '1' })
@@ -21,8 +22,8 @@ export class PaginasController {
   constructor(private readonly paginasService: PaginasService) {}
 
   @Get()
-  findAll(@Query('all') all = '0') {
-    return this.paginasService.findAll(all === '1');
+  findAll(@Query() pagination: PaginationDto, @Query('all') all = '0') {
+    return this.paginasService.findAll(all === '1', pagination);
   }
 
   @Post()

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -16,6 +16,7 @@ import { RolesService } from './roles.service';
 import { CreateRolDto } from './dto/create-rol.dto';
 import { UpdateRolDto } from './dto/update-rol.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PaginationDto } from 'src/shared/dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller({ path: 'roles', version: '1' })
@@ -23,8 +24,8 @@ export class RolesController {
   constructor(private readonly rolesService: RolesService) {}
 
   @Get()
-  findAll(@Query('all') all = '0') {
-    return this.rolesService.findAll(all === '1');
+  findAll(@Query() pagination: PaginationDto, @Query('all') all = '0') {
+    return this.rolesService.findAll(all === '1', pagination);
   }
 
   @Post()

--- a/src/shared/dto/index.ts
+++ b/src/shared/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './page.dto';
 export * from './me.dto';
+export * from './pagination.dto';

--- a/src/shared/dto/pagination.dto.ts
+++ b/src/shared/dto/pagination.dto.ts
@@ -1,0 +1,17 @@
+import { IsIn, IsInt, IsOptional, Min } from 'class-validator';
+
+export class PaginationDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  page?: number; // default 1
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  limit?: number; // default 10 (cap máx 100)
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sort?: 'asc' | 'desc'; // default 'desc'
+}

--- a/src/shared/utils/pagination.ts
+++ b/src/shared/utils/pagination.ts
@@ -1,0 +1,4 @@
+export function buildPageMeta(total: number, page: number, limit: number) {
+  const pages = Math.max(1, Math.ceil(total / Math.max(1, limit)));
+  return { total, page, limit, pages };
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -21,7 +21,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UpdateSignatureDto } from './dto/update-signature.dto';
-import { MeResponseDto } from 'src/shared/dto';
+import { MeResponseDto, PaginationDto } from 'src/shared/dto';
 import { ChangePasswordDto } from './dto/change-password.dto';
 
 @UseGuards(JwtAuthGuard)
@@ -41,8 +41,8 @@ export class UsersController {
   }
 
   @Get()
-  findAll(@Query('all') all = '0') {
-    return this.usersService.findAll(all === '1');
+  findAll(@Query() pagination: PaginationDto, @Query('all') all = '0') {
+    return this.usersService.findAll(all === '1', pagination);
   }
 
   @Get('me')


### PR DESCRIPTION
## Summary
- add shared pagination dto and pagination metadata helper for consistent paging
- update users, roles and paginas endpoints to support optional paginated responses without breaking legacy array output
- align supervision listings with the new pagination meta while keeping the previous payload fields

## Testing
- yarn lint *(fails: existing lint issues in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7c2ce68c8332954e061823fbd068