### PR TITLE
Normalize pagination envelopes

### DIFF
--- a/src/shared/utils/pagination.ts
+++ b/src/shared/utils/pagination.ts
@@ -1,3 +1,84 @@
+import { BadRequestException } from '@nestjs/common';
+
+export type SortDirection = 'asc' | 'desc';
+
+export interface PaginationInput {
+  page?: number | string;
+  limit?: number | string;
+  sort?: SortDirection | string;
+}
+
+export interface NormalizedPagination {
+  page: number;
+  limit: number;
+  sort: SortDirection;
+  skip: number;
+  take: number;
+}
+
+export function normalizePagination(
+  pagination?: PaginationInput,
+): NormalizedPagination {
+  const rawPage = pagination?.page ?? 1;
+  const rawLimit = pagination?.limit ?? 10;
+  const rawSort = pagination?.sort ?? 'desc';
+
+  const page = Number(rawPage);
+  if (!Number.isFinite(page) || !Number.isInteger(page)) {
+    throw new BadRequestException('El parámetro "page" debe ser un entero.');
+  }
+  if (page < 1) {
+    throw new BadRequestException('El parámetro "page" debe ser mayor o igual a 1.');
+  }
+
+  const limit = Number(rawLimit);
+  if (!Number.isFinite(limit) || !Number.isInteger(limit)) {
+    throw new BadRequestException('El parámetro "limit" debe ser un entero.');
+  }
+  if (limit < 1 || limit > 100) {
+    throw new BadRequestException(
+      'El parámetro "limit" debe estar entre 1 y 100.',
+    );
+  }
+
+  let sort: SortDirection;
+  if (rawSort === 'asc' || rawSort === 'desc') {
+    sort = rawSort;
+  } else if (typeof rawSort === 'string') {
+    sort = rawSort.toLowerCase() === 'asc' ? 'asc' : 'desc';
+  } else {
+    sort = 'desc';
+  }
+
+  return {
+    page,
+    limit,
+    sort,
+    skip: (page - 1) * limit,
+    take: limit,
+  };
+}
+
+export function buildPaginationResult<T>(
+  items: T[],
+  total: number,
+  page: number,
+  limit: number,
+  sort: SortDirection,
+) {
+  const pages = Math.ceil(total / limit);
+  return {
+    items,
+    page,
+    limit,
+    sort,
+    total,
+    pages,
+    hasPrev: page > 1,
+    hasNext: page < pages,
+  };
+}
+
 export function buildPageMeta(total: number, page: number, limit: number) {
   const pages = Math.max(1, Math.ceil(total / Math.max(1, limit)));
   return { total, page, limit, pages };

--- a/test/documents.e2e-spec.ts
+++ b/test/documents.e2e-spec.ts
@@ -6,34 +6,29 @@ import { JwtAuthGuard } from '../src/auth/guards/jwt-auth.guard';
 
 const documentsServiceMock = {
   listByUser: jest.fn().mockResolvedValue({
-    status: HttpStatus.ACCEPTED,
-    data: {
-      asignaciones: [
-        {
-          cuadro_firma: {
-            id: 1,
-            firmantesResumen: [
-              {
-                id: 2,
-                nombre: 'John Doe',
-                iniciales: 'JD',
-                urlFoto: null,
-                responsabilidad: 'Elabora',
-              },
-            ],
-          },
+    items: [
+      {
+        cuadro_firma: {
+          id: 1,
+          firmantesResumen: [
+            {
+              id: 2,
+              nombre: 'John Doe',
+              iniciales: 'JD',
+              urlFoto: null,
+              responsabilidad: 'Elabora',
+            },
+          ],
         },
-      ],
-      meta: {
-        totalCount: 1,
-        page: 1,
-        limit: 10,
-        totalPages: 1,
-        lastPage: 1,
-        hasNextPage: false,
-        hasPrevPage: false,
       },
-    },
+    ],
+    page: 1,
+    limit: 10,
+    sort: 'desc',
+    total: 1,
+    pages: 1,
+    hasPrev: false,
+    hasNext: false,
   }),
   getUsuariosFirmantesCuadroFirmas: jest.fn().mockResolvedValue({
     status: HttpStatus.ACCEPTED,
@@ -55,41 +50,36 @@ const documentsServiceMock = {
     ],
   }),
   listSupervision: jest.fn().mockResolvedValue({
-    status: HttpStatus.ACCEPTED,
-    data: {
-      documentos: [
-        {
-          id: 30,
-          titulo: 'Documento de Prueba 01',
-          descripcion: 'Documento de Prueba descripcion 01',
-          codigo: 'PR-001',
-          version: '2.0',
-          add_date: '2025-09-14T10:35:23.313Z',
-          estado_firma: { id: 4, nombre: 'Pendiente' },
-          empresa: { id: 1, nombre: 'FGE' },
-          diasTranscurridos: 0,
-          descripcionEstado: 'Cuadro de firmas generado',
-          firmantesResumen: [
-            {
-              id: 46,
-              nombre: 'Admin User',
-              iniciales: 'AU',
-              urlFoto: null,
-              responsabilidad: 'Elabora',
-            },
-          ],
-        },
-      ],
-      meta: {
-        totalCount: 1,
-        page: 1,
-        limit: 10,
-        totalPages: 1,
-        lastPage: 1,
-        hasNextPage: false,
-        hasPrevPage: false,
+    items: [
+      {
+        id: 30,
+        titulo: 'Documento de Prueba 01',
+        descripcion: 'Documento de Prueba descripcion 01',
+        codigo: 'PR-001',
+        version: '2.0',
+        add_date: '2025-09-14T10:35:23.313Z',
+        estado_firma: { id: 4, nombre: 'Pendiente' },
+        empresa: { id: 1, nombre: 'FGE' },
+        diasTranscurridos: 0,
+        descripcionEstado: 'Cuadro de firmas generado',
+        firmantesResumen: [
+          {
+            id: 46,
+            nombre: 'Admin User',
+            iniciales: 'AU',
+            urlFoto: null,
+            responsabilidad: 'Elabora',
+          },
+        ],
       },
-    },
+    ],
+    page: 1,
+    limit: 10,
+    sort: 'desc',
+    total: 1,
+    pages: 1,
+    hasPrev: false,
+    hasNext: false,
   }),
   statsSupervision: jest.fn().mockResolvedValue({
     status: HttpStatus.OK,
@@ -210,17 +200,14 @@ describe('DocumentsController (e2e)', () => {
       .get('/documents/cuadro-firmas/by-user/1?page=1&limit=10')
       .expect(HttpStatus.OK);
 
-    expect(
-      res.body.data.asignaciones[0].cuadro_firma.firmantesResumen,
-    ).toBeDefined();
-    expect(res.body.data.meta).toEqual({
-      totalCount: 1,
+    expect(res.body.items[0].cuadro_firma.firmantesResumen).toBeDefined();
+    expect(res.body).toMatchObject({
+      total: 1,
       page: 1,
       limit: 10,
-      totalPages: 1,
-      lastPage: 1,
-      hasNextPage: false,
-      hasPrevPage: false,
+      pages: 1,
+      hasNext: false,
+      hasPrev: false,
     });
   });
 
@@ -239,8 +226,8 @@ describe('DocumentsController (e2e)', () => {
       .get('/documents/cuadro-firmas/documentos/supervision?page=1&limit=10')
       .expect(HttpStatus.OK);
 
-    expect(res.body.data.documentos[0].firmantesResumen).toBeDefined();
-    expect(res.body.data.meta.totalCount).toBe(1);
+    expect(res.body.items[0].firmantesResumen).toBeDefined();
+    expect(res.body.total).toBe(1);
   });
 
   it('supervision stats returns counts', async () => {


### PR DESCRIPTION
## Summary
- add shared pagination helpers to validate query parameters and build uniform envelopes
- apply the normalized pagination flow to document supervision/by-user listings and to users, roles, and páginas services
- update the documents e2e expectations to cover the new response shape

## Testing
- yarn test *(fails: Unknown compiler option 'include')*

------
https://chatgpt.com/codex/tasks/task_e_68ccae185250833294c1ab9ae3884590