### PR TITLE
Ensure stable pagination ordering and tests

### DIFF
--- a/src/documents/documents.service.ts
+++ b/src/documents/documents.service.ts
@@ -46,6 +46,7 @@ import { resolvePhotoUrl } from 'src/shared/helpers/file.helpers';
 import {
   buildPaginationResult,
   normalizePagination,
+  stableOrder,
 } from 'src/shared/utils/pagination';
 
 @Injectable()
@@ -1132,17 +1133,11 @@ export class DocumentsService {
     };
   }
 
-  private buildOrder(sort: 'asc' | 'desc') {
-    return sort === 'asc'
-      ? [{ add_date: 'asc' as const }, { id: 'asc' as const }]
-      : [{ add_date: 'desc' as const }, { id: 'desc' as const }];
-  }
-
   async listSupervision(q: ListQueryDto) {
     const { page, limit, sort, skip, take } = normalizePagination(q);
 
     const where = this.buildWhere(q.search, q.estado);
-    const orderBy = this.buildOrder(sort);
+    const orderBy = stableOrder(sort);
 
     const [total, rows] = await this.prisma.$transaction([
       this.prisma.cuadro_firma.count({ where }),
@@ -1180,7 +1175,7 @@ export class DocumentsService {
     const where: Prisma.cuadro_firmaWhereInput = {
       AND: [whereDoc, { cuadro_firma_user: { some: { user_id: userId } } }],
     };
-    const orderBy = this.buildOrder(sort);
+    const orderBy = stableOrder(sort);
 
     const [total, rows] = await this.prisma.$transaction([
       this.prisma.cuadro_firma.count({ where }),

--- a/src/paginas/paginas.service.spec.ts
+++ b/src/paginas/paginas.service.spec.ts
@@ -1,0 +1,122 @@
+import { PaginasService } from './paginas.service';
+import { stableOrder } from 'src/shared/utils/pagination';
+
+describe('PaginasService pagination', () => {
+  const dataset = Array.from({ length: 16 }, (_, index) => ({
+    id: index + 1,
+    add_date: new Date(2024, 0, index + 1),
+    activo: true,
+  }));
+
+  const createPrismaMock = () => {
+    const count = jest.fn(() => Promise.resolve(dataset.length));
+    const findMany = jest.fn((args: any) => {
+      const { orderBy, skip = 0, take } = args ?? {};
+
+      if (!Array.isArray(orderBy) || orderBy.length === 0) {
+        throw new Error('Expected stable order definition');
+      }
+
+      if (typeof skip !== 'number') {
+        throw new Error('Expected skip to be provided to the ORM');
+      }
+
+      if (typeof take !== 'number') {
+        throw new Error('Expected take to be provided to the ORM');
+      }
+
+      const direction: 'asc' | 'desc' = orderBy[0]?.add_date ?? 'desc';
+
+      const sorted = [...dataset].sort((a, b) => {
+        const dateDiff = a.add_date.getTime() - b.add_date.getTime();
+        if (dateDiff !== 0) {
+          return direction === 'asc' ? dateDiff : -dateDiff;
+        }
+        return direction === 'asc' ? a.id - b.id : b.id - a.id;
+      });
+
+      const start = skip;
+      const end = start + take;
+      return Promise.resolve(sorted.slice(start, end));
+    });
+
+    const transaction = jest.fn((operations: Array<Promise<unknown>>) =>
+      Promise.all(operations),
+    );
+
+    const prisma = {
+      pagina: {
+        count,
+        findMany,
+      },
+      $transaction: transaction,
+    } as const;
+
+    return { prisma: prisma as unknown, count, findMany, transaction };
+  };
+
+  it('paginates with stable order and envelope metadata', async () => {
+    const { prisma, count, findMany } = createPrismaMock();
+    const service = new PaginasService(prisma as any);
+
+    const firstPage = await service.findAll(false, {
+      page: 1,
+      limit: 10,
+      sort: 'desc',
+    });
+
+    const secondPage = await service.findAll(false, {
+      page: 2,
+      limit: 10,
+      sort: 'desc',
+    });
+
+    expect(firstPage.items).toHaveLength(10);
+    expect(secondPage.items).toHaveLength(6);
+
+    const ids = [...firstPage.items, ...secondPage.items].map((item) => item.id);
+    expect(new Set(ids).size).toBe(dataset.length);
+
+    expect(firstPage).toMatchObject({
+      page: 1,
+      limit: 10,
+      sort: 'desc',
+      total: dataset.length,
+      pages: 2,
+      hasPrev: false,
+      hasNext: true,
+    });
+
+    expect(secondPage).toMatchObject({
+      page: 2,
+      limit: 10,
+      sort: 'desc',
+      total: dataset.length,
+      pages: 2,
+      hasPrev: true,
+      hasNext: false,
+    });
+
+    expect(findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        orderBy: stableOrder('desc'),
+        skip: 0,
+        take: 10,
+      }),
+    );
+
+    expect(findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        orderBy: stableOrder('desc'),
+        skip: 10,
+        take: 10,
+      }),
+    );
+
+    const countWhereArgs = count.mock.calls.map((call) => call[0]?.where);
+    const findManyWhereArgs = findMany.mock.calls.map((call) => call[0]?.where);
+    expect(countWhereArgs).toEqual(findManyWhereArgs);
+  });
+});

--- a/src/paginas/paginas.service.ts
+++ b/src/paginas/paginas.service.ts
@@ -7,6 +7,7 @@ import { PaginationDto } from 'src/shared/dto';
 import {
   buildPaginationResult,
   normalizePagination,
+  stableOrder,
 } from 'src/shared/utils/pagination';
 
 @Injectable()
@@ -29,10 +30,7 @@ export class PaginasService {
       this.prisma.pagina.count({ where }),
       this.prisma.pagina.findMany({
         where,
-        orderBy: [
-          { add_date: sort },
-          { id: sort },
-        ],
+        orderBy: stableOrder(sort),
         take,
         skip,
       }),

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -12,6 +12,7 @@ import { PageDto, PaginationDto } from '../shared/dto';
 import {
   buildPaginationResult,
   normalizePagination,
+  stableOrder,
 } from 'src/shared/utils/pagination';
 
 @Injectable()
@@ -42,10 +43,7 @@ export class RolesService {
       this.prisma.rol.count({ where }),
       this.prisma.rol.findMany({
         where,
-        orderBy: [
-          { add_date: sort },
-          { id: sort },
-        ],
+        orderBy: stableOrder(sort),
         take,
         skip,
         select,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -22,6 +22,7 @@ import { extname } from 'path';
 import {
   buildPaginationResult,
   normalizePagination,
+  stableOrder,
 } from 'src/shared/utils/pagination';
 
 const userSummarySelect = {
@@ -150,10 +151,7 @@ export class UsersService {
       this.prisma.user.count({ where }),
       this.prisma.user.findMany({
         where,
-        orderBy: [
-          { add_date: sort },
-          { id: sort },
-        ],
+        orderBy: stableOrder(sort),
         take,
         skip,
         select: userSummarySelect,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": ".",
-    "include": ["src", "prisma/generated/prisma"],
     "paths": {
       "generated/prisma": ["prisma/generated/prisma"]
     },
@@ -25,5 +24,6 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "include": ["src", "prisma/generated/prisma"]
 }


### PR DESCRIPTION
## Summary
- clamp pagination parameters, expose a shared `stableOrder` helper and ensure the envelope keeps a minimum of one page
- update documents, users, roles and páginas listings to reuse the shared stable order with ORM-level skip/take
- add pagination unit coverage with a Prisma mock and refresh documents service specs; move the TypeScript include to the root of `tsconfig.json`

## Testing
- yarn test --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ccc75375748332acd83b4031f53e9b