### PR TITLE
feat(documents): stream pdf summary via openai

### DIFF
--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AiService } from './ai.service';
 import { AiController } from './ai.controller';
+import { OpenAiProvider } from './providers/open-ai.provider';
 
 @Module({
   controllers: [AiController],
-  providers: [AiService],
+  providers: [OpenAiProvider, AiService],
   exports: [AiService],
 })
 export class AiModule {}

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -1,37 +1,15 @@
 import { Injectable } from '@nestjs/common';
-import { AIProvider } from './providers/ai-provider.interface';
 import { OpenAiProvider } from './providers/open-ai.provider';
 
 @Injectable()
 export class AiService {
-  private providers: AIProvider[];
+  constructor(private readonly openai: OpenAiProvider) {}
 
-  constructor() {
-    this.providers = [
-      new OpenAiProvider(),
-    ]
+  generateText(prompt: string) {
+    return this.openai.generateText(prompt);
   }
 
-  async generateText( prompt: any ) {
-    for(const provider of this.providers) {
-      try {
-        const result = await provider.generateText(prompt);
-        if(result) return result;
-      } catch (error) {
-        throw new Error(`Provider failed: ${error}`);
-      }
-    }
+  summarizePDF(pdfContent: string) {
+    return this.openai.summarizePDF(pdfContent);
   }
-
-  async summarizePDF( pdfContent: string ) {
-    for(const provider of this.providers) {
-      try {
-        const result = await provider.summarizePDF(pdfContent);
-        if(result) return result;
-      } catch (error) {
-        throw new Error(`Provider failed: ${error}`);
-      }
-    }
-  }
-
 }

--- a/src/ai/providers/ai-provider.interface.ts
+++ b/src/ai/providers/ai-provider.interface.ts
@@ -1,6 +1,6 @@
 export const AI_PROVIDER = Symbol('AI_PROVIDER');
 
 export interface AIProvider {
-    generateText(prompt: string): Promise<string>;
-    summarizePDF(pdfContent: string): Promise<string>;
+  generateText(prompt: string): Promise<string>;
+  summarizePDF(pdfContent: string): Promise<AsyncIterable<unknown>>;
 }

--- a/src/config/envs.ts
+++ b/src/config/envs.ts
@@ -23,7 +23,7 @@ const envsSchema = joi
     S3_BUCKET_SECRET_KEY: joi.string().optional().allow(''),
 
     OPENAI_API_KEY: joi.string().optional().allow(''),
-    OPENAI_MODEL: joi.string().optional().allow(''),
+    OPENAI_MODEL: joi.string().default('gpt-4o-mini'),
   })
   .unknown(true);
 

--- a/src/database/domain/repositories/documentos.repository.ts
+++ b/src/database/domain/repositories/documentos.repository.ts
@@ -9,4 +9,8 @@ export abstract class DocumentosRepository {
       [key: string]: any;
     },
   ): Promise<Prisma.BatchPayload>;
+
+  abstract findByCuadroFirmaID(
+    cuadroFirmaID: number,
+  ): Promise<{ nombre_archivo: string | null } | null>;
 }

--- a/src/database/infrastructure/pirsma-documentos.repository.ts
+++ b/src/database/infrastructure/pirsma-documentos.repository.ts
@@ -32,4 +32,13 @@ export class PrismaDocumentosRepository implements DocumentosRepository {
       );
     }
   }
+
+  findByCuadroFirmaID(cuadroFirmaID: number) {
+    return this.prisma.documento.findFirst({
+      where: { cuadro_firma_id: cuadroFirmaID },
+      select: {
+        nombre_archivo: true,
+      },
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- add an injectable OpenAI provider with streaming PDF summarization and wire it into the AI module/service
- expose a DocumentsService helper to pull PDF content from storage and iterate the summary stream from a new controller endpoint
- extend repositories/config/tests so the PDF extraction workflow is reusable and validated

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68cce747f5f48332a162cf22eadc7c88