### PR TITLE
Add merged PDF endpoint for documents

### DIFF
--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -223,8 +223,28 @@ export class DocumentsController {
       urlCuadroFirmasPDF: urlCuadroFirmasPDF.data.data,
       urlDocumento: urlDocumento.data.data,
       ...cuadroFirmasDB,
-      
     };
+  }
+
+  @Get('cuadro-firmas/:id/merged-pdf')
+  async getMergedPDF(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('download') download: string,
+    @Res() res: Response,
+  ) {
+    const merged = await this.documentsService.getMergedDocuments(id);
+    res.setHeader('Content-Type', 'application/pdf');
+    const isDownload = download === '1' || download === 'true';
+    res.setHeader(
+      'Content-Disposition',
+      isDownload
+        ? 'attachment; filename="documento-firmas.pdf"'
+        : 'inline; filename="merged.pdf"',
+    );
+    if (typeof merged?.length === 'number') {
+      res.setHeader('Content-Length', merged.length.toString());
+    }
+    return res.send(merged);
   }
 
   @Post('cuadro-firmas')

--- a/src/pdf/domain/repositories/pdf.repository.ts
+++ b/src/pdf/domain/repositories/pdf.repository.ts
@@ -96,6 +96,8 @@ export interface PdfRepository {
     values: Record<'NOMBRE' | 'PUESTO' | 'GERENCIA' | 'FECHA', string>,
     options?: FillRowByColumnsOptions,
   ): Promise<FillRowByColumnsResult>;
+
+  mergePDFs(pdfBuffers: Buffer[]): Promise<Buffer>;
 }
 
 export const CELL = { height: 22, textSize: 8 } as const;

--- a/src/pdf/infrastructure/pdf-lib.repository.ts
+++ b/src/pdf/infrastructure/pdf-lib.repository.ts
@@ -840,6 +840,33 @@ export class PdfLibRepository implements PdfRepository {
     return { buffer, mode: 'columns' };
   }
 
+  async mergePDFs(pdfBuffers: Buffer[]): Promise<Buffer> {
+    if (!Array.isArray(pdfBuffers) || pdfBuffers.length === 0) {
+      throw new Error('No se proporcionaron PDFs para combinar');
+    }
+
+    const mergedPdf = await PDFDocument.create();
+
+    for (const buffer of pdfBuffers) {
+      if (!buffer?.length) {
+        throw new Error('Uno de los PDFs recibidos está vacío');
+      }
+
+      const pdfDoc = await PDFDocument.load(buffer);
+      const copiedPages = await mergedPdf.copyPages(
+        pdfDoc,
+        pdfDoc.getPageIndices(),
+      );
+
+      for (const page of copiedPages) {
+        mergedPdf.addPage(page);
+      }
+    }
+
+    const mergedBytes = await mergedPdf.save();
+    return Buffer.from(mergedBytes);
+  }
+
   private truncateText(
     font: PDFFont,
     text: string,


### PR DESCRIPTION
## Summary
- add DocumentsService.getMergedDocuments to download and combine original and signature PDFs
- expose GET /api/documents/cuadro-firmas/:id/merged-pdf endpoint with optional download
- extend PDF repository with mergePDFs implementation and cover with unit and e2e tests

## Testing
- yarn test
- yarn test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68cd090975088332b103a4786e6caec4