### PR TITLE
feat: paginate notifications and secure websocket notifications

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['eslint.config.mjs'],
+    ignores: ['eslint.config.mjs', 'generated/**'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
@@ -28,7 +28,7 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn'
+      '@typescript-eslint/no-unsafe-argument': 'warn',
     },
   },
 );

--- a/src/database/domain/repositories/notificaciones.repository.ts
+++ b/src/database/domain/repositories/notificaciones.repository.ts
@@ -1,14 +1,48 @@
-import { notificacion, Prisma } from "generated/prisma";
-import { CreateNotificationDto } from "src/documents/dto/create-notification.dto";
-import { UpdateNotificationDto } from "src/documents/dto/update-notification.dto";
+import type { notificacion, Prisma } from 'generated/prisma';
+import type { PaginationDto } from 'src/common/dto/pagination.dto';
+import { CreateNotificationDto } from 'src/documents/dto/create-notification.dto';
+import { UpdateNotificationDto } from 'src/documents/dto/update-notification.dto';
 
 export const NOTIFICACIONES_REPOSITORY = 'NOTIFICACIONES_REPOSITORY';
 
+export type NotificationWithMetadata = Prisma.notificacion_userGetPayload<{
+  include: {
+    notificacion: true;
+  };
+}>;
+
+export interface NotificationQueryOptions {
+  pagination: Pick<PaginationDto, 'page' | 'limit'>;
+  since?: Date;
+}
+
+export interface NotificationQueryResult {
+  items: NotificationWithMetadata[];
+  total: number;
+}
+
 export abstract class NotificacionesRepository {
-  abstract createNotification(createNotificationDto: CreateNotificationDto): Promise<notificacion>;
-  abstract updateNotification(updateNotificationDto: UpdateNotificationDto): Promise<void>;
+  abstract createNotification(
+    createNotificationDto: CreateNotificationDto,
+  ): Promise<notificacion>;
+  abstract updateNotification(
+    updateNotificationDto: UpdateNotificationDto,
+  ): Promise<void>;
   abstract findNotificationById(notificationId: number): Promise<void>;
-  abstract findUserNotification(notificationId: number, userId: number): Promise<void>;
-  abstract createUserNotification(notificationId: number, userId: number): Promise<void>;
-  abstract getNotificationsByUser(userId: number);
+  abstract findUserNotification(
+    notificationId: number,
+    userId: number,
+  ): Promise<void>;
+  abstract createUserNotification(
+    notificationId: number,
+    userId: number,
+  ): Promise<void>;
+  abstract getNotificationsByUser(
+    userId: number,
+    options: NotificationQueryOptions,
+  ): Promise<NotificationQueryResult>;
+  abstract markNotificationsAsRead(
+    userId: number,
+    notificationIds?: number[],
+  ): Promise<number>;
 }

--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -35,7 +35,14 @@ import { envs } from 'src/config/envs';
 import { AiService } from 'src/ai/ai.service';
 import type { Response } from 'express';
 import { UpdateNotificationDto } from './dto/update-notification.dto';
+import {
+  NotificationBulkReadDto,
+  NotificationListResponseDto,
+  NotificationPaginationDto,
+} from './dto/notification-response.dto';
+import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Documents')
 @Controller('documents')
 export class DocumentsController {
   logger: Logger = new Logger(DocumentsController.name);
@@ -375,19 +382,54 @@ export class DocumentsController {
     );
   }
 
-  
   @Patch('cuadro-firmas/notificaciones/leer')
+  @ApiOperation({ summary: 'Marcar una notificación como leída' })
+  @ApiOkResponse({
+    schema: {
+      properties: {
+        status: { type: 'number', example: 200 },
+        data: { type: 'boolean' },
+      },
+    },
+  })
   updateNotificationByUserId(
-    // @Body() updateNotificationDto: UpdateNotificationDto,
     @Body('userId', ParseIntPipe) userId: number,
     @Body('notificationId', ParseIntPipe) notificationId: number,
   ) {
-    return this.documentsService.updateNotificationByUserId(notificationId, userId);
+    return this.documentsService.updateNotificationByUserId(
+      notificationId,
+      userId,
+    );
   }
-  
+
+  @Patch('cuadro-firmas/notificaciones/leer-todas')
+  @ApiOperation({ summary: 'Marcar notificaciones como leídas' })
+  @ApiBody({ type: NotificationBulkReadDto })
+  @ApiOkResponse({
+    schema: {
+      properties: {
+        status: { type: 'number', example: 200 },
+        data: {
+          type: 'object',
+          properties: {
+            updated: { type: 'number', example: 3 },
+          },
+        },
+      },
+    },
+  })
+  markNotificationsAsRead(@Body() bulkReadDto: NotificationBulkReadDto) {
+    return this.documentsService.markNotificationsAsRead(bulkReadDto);
+  }
+
   @Get('cuadro-firmas/notificaciones/:userId')
-  getNotificationsByUser(@Param('userId', ParseIntPipe) userId: number) {
-    return this.documentsService.getNotificationsByUser(userId);
+  @ApiOperation({ summary: 'Listar notificaciones del usuario' })
+  @ApiOkResponse({ type: NotificationListResponseDto })
+  getNotificationsByUser(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Query() pagination: NotificationPaginationDto,
+  ) {
+    return this.documentsService.getNotificationsByUser(userId, pagination);
   }
   @Patch('cuadro-firmas/:id')
   updateCuadroFirmas(
@@ -401,5 +443,4 @@ export class DocumentsController {
       responsables,
     );
   }
-  
 }

--- a/src/documents/dto/notification-response.dto.ts
+++ b/src/documents/dto/notification-response.dto.ts
@@ -1,0 +1,148 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsPositive,
+  IsString,
+  Matches,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export const NOTIFICATIONS_PAYLOAD_VERSION = '1.0';
+
+export class NotificationItemDto {
+  @ApiProperty({ example: 123 })
+  @IsInt()
+  id!: number;
+
+  @ApiProperty({ example: 'Nuevo documento disponible' })
+  @IsString()
+  title!: string;
+
+  @ApiProperty({
+    example: 'Se asignó el documento "Contrato" para su revisión.',
+  })
+  @IsString()
+  message!: string;
+
+  @ApiProperty({ example: '2025-01-01T15:04:05.000Z' })
+  @IsDateString()
+  createdAt!: string;
+
+  @ApiProperty({ example: false })
+  isRead!: boolean;
+
+  @ApiProperty({ example: '/app/documents/1', nullable: true })
+  @IsOptional()
+  @IsString()
+  href: string | null = null;
+
+  @ApiProperty({ example: 'info', nullable: true })
+  @IsOptional()
+  @IsString()
+  icon: string | null = null;
+}
+
+export class NotificationMetaDto {
+  @ApiProperty({ example: 1 })
+  @IsInt()
+  page!: number;
+
+  @ApiProperty({ example: 10 })
+  @IsInt()
+  limit!: number;
+
+  @ApiProperty({ example: 57 })
+  @IsInt()
+  total!: number;
+
+  @ApiProperty({ example: 6 })
+  @IsInt()
+  pages!: number;
+
+  @ApiProperty({ example: true })
+  hasNext!: boolean;
+
+  @ApiProperty({ example: false })
+  hasPrev!: boolean;
+}
+
+export class NotificationPayloadDto {
+  @ApiProperty({ type: [NotificationItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => NotificationItemDto)
+  items!: NotificationItemDto[];
+
+  @ApiProperty({ type: NotificationMetaDto })
+  @ValidateNested()
+  @Type(() => NotificationMetaDto)
+  meta!: NotificationMetaDto;
+}
+
+export class NotificationEnvelopeDto {
+  @ApiProperty({ example: NOTIFICATIONS_PAYLOAD_VERSION })
+  @Matches(/^1\.0$/)
+  version: string = NOTIFICATIONS_PAYLOAD_VERSION;
+
+  @ApiProperty({ type: NotificationPayloadDto })
+  @ValidateNested()
+  @Type(() => NotificationPayloadDto)
+  data!: NotificationPayloadDto;
+}
+
+export class NotificationListResponseDto extends NotificationEnvelopeDto {
+  @ApiProperty({ example: 200 })
+  @IsInt()
+  status!: number;
+}
+
+export class NotificationPaginationDto {
+  @ApiProperty({ required: false, example: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiProperty({ required: false, example: 10 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  limit?: number = 10;
+
+  @ApiProperty({ required: false, example: '2025-01-01T15:04:05.000Z' })
+  @IsOptional()
+  @IsDateString()
+  since?: string;
+}
+
+export class NotificationBulkReadDto {
+  @ApiProperty({ example: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  userId!: number;
+
+  @ApiProperty({ required: false, type: [Number], example: [10, 11, 15] })
+  @IsOptional()
+  @IsArray()
+  @Type(() => Number)
+  @IsInt({ each: true })
+  ids?: number[];
+}
+
+export class UserNotificationsClientDto extends NotificationPaginationDto {
+  @ApiProperty({ example: NOTIFICATIONS_PAYLOAD_VERSION })
+  @Matches(/^1\.0$/)
+  version!: string;
+}
+
+export class UserNotificationsServerDto extends NotificationEnvelopeDto {}

--- a/src/documents/utils/notification.presenter.ts
+++ b/src/documents/utils/notification.presenter.ts
@@ -1,0 +1,71 @@
+import { buildPageMeta } from 'src/shared/utils/pagination';
+import type { NotificationWithMetadata } from 'src/database/domain/repositories/notificaciones.repository';
+import { NOTIFICATIONS_PAYLOAD_VERSION } from '../dto/notification-response.dto';
+
+export interface NotificationViewModel {
+  id: number;
+  title: string;
+  message: string;
+  createdAt: string;
+  isRead: boolean;
+  href: string | null;
+  icon: string | null;
+}
+
+export interface NotificationMetaViewModel {
+  page: number;
+  limit: number;
+  total: number;
+  pages: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+export interface NotificationListViewModel {
+  version: string;
+  data: {
+    items: NotificationViewModel[];
+    meta: NotificationMetaViewModel;
+  };
+}
+
+export function mapNotification(
+  item: NotificationWithMetadata,
+): NotificationViewModel {
+  const { notificacion, fue_leido } = item;
+  const href = notificacion.referencia_id
+    ? `/documents/cuadro-firmas/${notificacion.referencia_id}`
+    : null;
+
+  return {
+    id: notificacion.id,
+    title: notificacion.titulo,
+    message: notificacion.contenido,
+    createdAt: (notificacion.add_date ?? new Date()).toISOString(),
+    isRead: Boolean(fue_leido),
+    href,
+    icon: notificacion.tipo ?? null,
+  };
+}
+
+export function buildNotificationPayload(
+  records: NotificationWithMetadata[],
+  total: number,
+  page: number,
+  limit: number,
+): NotificationListViewModel {
+  const metaBase = buildPageMeta(total, page, limit);
+  const meta = {
+    ...metaBase,
+    hasPrev: page > 1,
+    hasNext: page < metaBase.pages,
+  };
+
+  return {
+    version: NOTIFICATIONS_PAYLOAD_VERSION,
+    data: {
+      items: records.map(mapNotification),
+      meta,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- expose paginated REST notifications with versioned DTOs and Swagger documentation, plus a bulk mark-as-read endpoint
- extend the notifications repository to support pagination/updateMany workflows and share a presenter utility between REST and websockets
- harden the websocket gateway with cookie parsing, access-token validation, payload validation, and structured logging while unifying the emitted payload shape

## Testing
- yarn lint *(fails: repository contains widespread pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d42c054d788332a809e30a8fa7a1fb