### PR TITLE
Fix pagination query coercion and inactive flag handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ async function bootstrap() {
       whitelist: true,
       forbidNonWhitelisted: false,
       transform: true,
+      transformOptions: { enableImplicitConversion: true },
     }),
   );
 

--- a/src/paginas/paginas.controller.ts
+++ b/src/paginas/paginas.controller.ts
@@ -14,7 +14,7 @@ import { PaginasService } from './paginas.service';
 import { CreatePaginaDto } from './dto/create-pagina.dto';
 import { UpdatePaginaDto } from './dto/update-pagina.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { PaginationDto } from 'src/shared/dto';
+import { InactiveFlagDto, PaginationDto } from 'src/shared/dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller({ path: 'paginas', version: '1' })
@@ -22,8 +22,9 @@ export class PaginasController {
   constructor(private readonly paginasService: PaginasService) {}
 
   @Get()
-  findAll(@Query() pagination: PaginationDto, @Query('all') all = '0') {
-    return this.paginasService.findAll(all === '1', pagination);
+  findAll(@Query() pagination: PaginationDto, @Query() q: InactiveFlagDto) {
+    const includeInactive = (q.includeInactive ?? q.showInactive ?? q.all) ?? false;
+    return this.paginasService.findAll(includeInactive, pagination);
   }
 
   @Post()

--- a/src/paginas/paginas.service.ts
+++ b/src/paginas/paginas.service.ts
@@ -15,15 +15,8 @@ import {
 export class PaginasService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll(all = false, pagination?: PaginationDto) {
-    const where = all ? undefined : { activo: true };
-
-    if (all) {
-      return this.prisma.pagina.findMany({
-        where,
-        orderBy: { id: 'asc' },
-      });
-    }
+  async findAll(includeInactive = false, pagination?: PaginationDto) {
+    const where = includeInactive ? undefined : { activo: true };
 
     const { page, limit, sort, skip, take } = normalizePagination(pagination);
     const orderBy = stableOrder(sort);

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -16,7 +16,7 @@ import { RolesService } from './roles.service';
 import { CreateRolDto } from './dto/create-rol.dto';
 import { UpdateRolDto } from './dto/update-rol.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { PaginationDto } from 'src/shared/dto';
+import { InactiveFlagDto, PaginationDto } from 'src/shared/dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller({ path: 'roles', version: '1' })
@@ -24,8 +24,9 @@ export class RolesController {
   constructor(private readonly rolesService: RolesService) {}
 
   @Get()
-  findAll(@Query() pagination: PaginationDto, @Query('all') all = '0') {
-    return this.rolesService.findAll(all === '1', pagination);
+  findAll(@Query() pagination: PaginationDto, @Query() q: InactiveFlagDto) {
+    const includeInactive = (q.includeInactive ?? q.showInactive ?? q.all) ?? false;
+    return this.rolesService.findAll(includeInactive, pagination);
   }
 
   @Post()

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -20,8 +20,8 @@ import {
 export class RolesService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll(all = false, pagination?: PaginationDto) {
-    const where = all ? undefined : { activo: true };
+  async findAll(includeInactive = false, pagination?: PaginationDto) {
+    const where = includeInactive ? undefined : { activo: true };
     const select = {
       id: true,
       nombre: true,
@@ -29,14 +29,6 @@ export class RolesService {
       activo: true,
       add_date: true,
     } as const;
-
-    if (all) {
-      return this.prisma.rol.findMany({
-        where,
-        orderBy: { id: 'asc' },
-        select,
-      });
-    }
 
     const { page, limit, sort, skip, take } = normalizePagination(pagination);
     const orderBy = stableOrder(sort);

--- a/src/shared/dto/pagination.dto.ts
+++ b/src/shared/dto/pagination.dto.ts
@@ -1,17 +1,48 @@
-import { IsIn, IsInt, IsOptional, Min } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsIn, IsInt, IsOptional, Min } from 'class-validator';
 
 export class PaginationDto {
+  @Type(() => Number)
   @IsOptional()
   @IsInt()
   @Min(1)
-  page?: number; // default 1
+  page: number = 1;
 
+  @Type(() => Number)
   @IsOptional()
   @IsInt()
   @Min(1)
-  limit?: number; // default 10 (cap máx 100)
+  limit: number = 10;
 
   @IsOptional()
   @IsIn(['asc', 'desc'])
-  sort?: 'asc' | 'desc'; // default 'desc'
+  sort: 'asc' | 'desc' = 'desc';
+}
+
+// Acepta includeInactive/showInactive/all con prioridad includeInactive
+export class InactiveFlagDto {
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => {
+    const v = String(value).toLowerCase().trim();
+    if (['1', 'true', 'on', 'yes'].includes(v)) return true;
+    if (['0', 'false', 'off', 'no'].includes(v)) return false;
+    return undefined; // si no viene, queda undefined
+  })
+  includeInactive?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => {
+    const v = String(value).toLowerCase().trim();
+    if (['1', 'true', 'on', 'yes'].includes(v)) return true;
+    if (['0', 'false', 'off', 'no'].includes(v)) return false;
+    return undefined;
+  })
+  showInactive?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => String(value).trim() === '1')
+  all?: boolean;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -21,7 +21,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UpdateSignatureDto } from './dto/update-signature.dto';
-import { MeResponseDto, PaginationDto } from 'src/shared/dto';
+import { InactiveFlagDto, MeResponseDto, PaginationDto } from 'src/shared/dto';
 import { ChangePasswordDto } from './dto/change-password.dto';
 
 @UseGuards(JwtAuthGuard)
@@ -41,8 +41,9 @@ export class UsersController {
   }
 
   @Get()
-  findAll(@Query() pagination: PaginationDto, @Query('all') all = '0') {
-    return this.usersService.findAll(all === '1', pagination);
+  findAll(@Query() pagination: PaginationDto, @Query() q: InactiveFlagDto) {
+    const includeInactive = (q.includeInactive ?? q.showInactive ?? q.all) ?? false;
+    return this.usersService.findAll(includeInactive, pagination);
   }
 
   @Get('me')

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -134,17 +134,8 @@ export class UsersService {
     return this.mapUser(finalUser!);
   }
 
-  async findAll(includeAll = false, pagination?: PaginationDto) {
-    const where = includeAll ? undefined : { activo: true };
-
-    if (includeAll) {
-      const users = await this.prisma.user.findMany({
-        where,
-        orderBy: { id: 'asc' },
-        select: userSummarySelect,
-      });
-      return Promise.all(users.map((user) => this.mapUser(user)));
-    }
+  async findAll(includeInactive = false, pagination?: PaginationDto) {
+    const where = includeInactive ? undefined : { activo: true };
 
     const { page, limit, sort, skip, take } = normalizePagination(pagination);
     const orderBy = stableOrder(sort);


### PR DESCRIPTION
## Summary
- coerce pagination query params and normalize inactive flag aliases through shared DTOs
- update roles, users, and páginas controllers and services to honor includeInactive while keeping paginated responses
- enable implicit type conversion in the global validation pipe to support class-transformer defaults

## Testing
- yarn lint *(fails: existing lint issues across untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c014f6548332a36c8a3a010277e9