### PR TITLE
Update notification hrefs for cuadro firmas documents

### DIFF
--- a/src/documents/dto/notification-response.dto.ts
+++ b/src/documents/dto/notification-response.dto.ts
@@ -38,10 +38,9 @@ export class NotificationItemDto {
   @ApiProperty({ example: false })
   isRead!: boolean;
 
-  @ApiProperty({ example: '/app/documents/1', nullable: true })
-  @IsOptional()
+  @ApiProperty({ example: '/documento/1' })
   @IsString()
-  href: string | null = null;
+  href!: string;
 
   @ApiProperty({ example: 'info', nullable: true })
   @IsOptional()

--- a/src/documents/utils/notification.presenter.ts
+++ b/src/documents/utils/notification.presenter.ts
@@ -8,7 +8,7 @@ export interface NotificationViewModel {
   message: string;
   createdAt: string;
   isRead: boolean;
-  href: string | null;
+  href: string;
   icon: string | null;
 }
 
@@ -33,9 +33,41 @@ export function mapNotification(
   item: NotificationWithMetadata,
 ): NotificationViewModel {
   const { notificacion, fue_leido } = item;
-  const href = notificacion.referencia_id
-    ? `/documents/cuadro-firmas/${notificacion.referencia_id}`
-    : null;
+
+  const notificationRecord = notificacion as unknown as Record<string, unknown>;
+  const itemRecord = item as unknown as Record<string, unknown>;
+
+  const candidateIds = [
+    notificacion.referencia_id,
+    notificationRecord.cuadro_firma_id,
+    notificationRecord.documentId,
+    notificationRecord.document_id,
+    notificationRecord.targetId,
+    notificationRecord.target_id,
+    itemRecord.cuadro_firma_id,
+    itemRecord.documentId,
+    itemRecord.document_id,
+    itemRecord.targetId,
+    itemRecord.target_id,
+  ];
+
+  const directDocId = candidateIds.find((value) =>
+    typeof value === 'number' && Number.isFinite(value),
+  ) as number | undefined;
+
+  const extractIdFromHref = (href?: unknown) => {
+    if (typeof href !== 'string') {
+      return null;
+    }
+    const match = href.match(/(\d+)(?!.*\d)/);
+    return match ? Number(match[1]) : null;
+  };
+
+  const legacyHref = notificationRecord.href ?? itemRecord.href;
+
+  const docId = directDocId ?? extractIdFromHref(legacyHref);
+
+  const href = docId ? `/documento/${docId}` : '';
 
   return {
     id: notificacion.id,


### PR DESCRIPTION
## Summary
- map document notifications to return frontend-ready /documento/:id links derived from available identifiers or legacy hrefs
- require href to be a string across notification view models and DTOs to keep the response contract consistent

## Testing
- yarn lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d67732e48883328031d4c66caa5b11