### PR TITLE
feat: add empresas listing endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { PaginasModule } from './paginas/paginas.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { PosicionesModule } from './posiciones/posiciones.module';
 import { GerenciasModule } from './gerencias/gerencias.module';
+import { EmpresasModule } from './empresas/empresas.module';
 import { WsModule } from './ws/ws.module';
 
 @Module({
@@ -37,6 +38,7 @@ import { WsModule } from './ws/ws.module';
     AwsModule,
     PosicionesModule,
     GerenciasModule,
+    EmpresasModule,
     WsModule,
   ],
   controllers: [AppController],

--- a/src/empresas/dto/find-empresas.dto.ts
+++ b/src/empresas/dto/find-empresas.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class FindEmpresasQueryDto {
+  @ApiPropertyOptional({
+    description: 'Filtra empresas por estado de actividad',
+    type: Boolean,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => {
+    if (value === undefined || value === null || value === '') {
+      return undefined;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    const normalized = String(value).toLowerCase().trim();
+    if (['1', 'true', 'on', 'yes'].includes(normalized)) {
+      return true;
+    }
+    if (['0', 'false', 'off', 'no'].includes(normalized)) {
+      return false;
+    }
+    return value;
+  })
+  activo?: boolean;
+}
+
+export class EmpresaListItemDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'Empresa Demo' })
+  nombre: string;
+
+  @ApiProperty({ type: Boolean, nullable: true, example: true })
+  activo: boolean | null;
+
+  @ApiProperty({ nullable: true, example: 'https://cdn.example.com/logo.png' })
+  logo: string | null;
+}
+
+export class FindEmpresasResponseDto {
+  @ApiProperty({ type: [EmpresaListItemDto] })
+  items: EmpresaListItemDto[];
+
+  @ApiProperty({ example: 1 })
+  total: number;
+}

--- a/src/empresas/empresas.controller.ts
+++ b/src/empresas/empresas.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { EmpresasService } from './empresas.service';
+import {
+  EmpresaListItemDto,
+  FindEmpresasQueryDto,
+  FindEmpresasResponseDto,
+} from './dto/find-empresas.dto';
+
+@ApiTags('Empresas')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller({ path: 'empresas', version: '1' })
+export class EmpresasController {
+  constructor(private readonly empresasService: EmpresasService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Lista las empresas registradas' })
+  @ApiOkResponse({
+    description: 'Listado paginado de empresas',
+    type: FindEmpresasResponseDto,
+  })
+  findAll(@Query() query: FindEmpresasQueryDto): Promise<{
+    items: EmpresaListItemDto[];
+    total: number;
+  }> {
+    return this.empresasService.findAll(query);
+  }
+}

--- a/src/empresas/empresas.module.ts
+++ b/src/empresas/empresas.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { EmpresasController } from './empresas.controller';
+import { EmpresasService } from './empresas.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [EmpresasController],
+  providers: [EmpresasService],
+})
+export class EmpresasModule {}

--- a/src/empresas/empresas.service.ts
+++ b/src/empresas/empresas.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { FindEmpresasQueryDto } from './dto/find-empresas.dto';
+
+@Injectable()
+export class EmpresasService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(query: FindEmpresasQueryDto) {
+    const where =
+      query.activo === undefined
+        ? undefined
+        : {
+            activo: query.activo,
+          };
+
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.empresa.findMany({
+        where,
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          nombre: true,
+          activo: true,
+          logo: true,
+        },
+      }),
+      this.prisma.empresa.count({ where }),
+    ]);
+
+    return { items, total };
+  }
+}


### PR DESCRIPTION
## Summary
- add Empresas module with a secured GET /empresas endpoint to list companies with Swagger docs
- support optional activo filter and typed DTO/response using Prisma

## Testing
- yarn lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db8c2101008332bd8f65a7bc651562